### PR TITLE
perf: optimize recurring expense confirmation

### DIFF
--- a/src/app/recurring/page.tsx
+++ b/src/app/recurring/page.tsx
@@ -260,7 +260,15 @@ export default function RecurringPage() {
 
       setGeneratingId(null);
       setGenerateAmount("");
-      fetchData();
+
+      // Update state locally instead of refetching all data
+      setRecurringExpenses((prev) =>
+        prev.map((e) =>
+          e.id === expense.id
+            ? { ...e, transactions: [data, ...e.transactions] }
+            : e
+        )
+      );
     } catch (error) {
       toast({
         title: "Erro",


### PR DESCRIPTION
## Summary

- Fixes issue where confirming a recurring expense value caused the page to visually "refresh"
- Instead of calling `fetchData()` (which triggers 4 API calls), now updates local state directly with the transaction returned from the API
- Provides instant feedback allowing users to mark multiple expenses quickly

## Test plan

- [ ] Navigate to /recurring page
- [ ] Click "Gerar" on a recurring expense without a transaction this month
- [ ] Enter a value and confirm
- [ ] Verify the badge changes to "Gerado" instantly without page flicker
- [ ] Verify you can immediately confirm another expense without waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)