### PR TITLE
fix: remove leaked Neon endpoint IDs from docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,18 @@ npm run test:all      # Run all tests
 
 TypeScript path alias: `@/*` maps to `./src/*`
 
+## Security: No Credentials in Code or Docs
+
+**NEVER commit real credentials, connection strings, API keys, endpoint identifiers, or secrets to the repository** — not in code, not in configuration, not in documentation, not in examples, not in comments. This includes:
+
+- Database URIs or connection strings with real hostnames/endpoints (e.g., Neon endpoint IDs like `ep-xxx-pooler`)
+- API keys, tokens, or passwords
+- Service-specific identifiers that could be used to target infrastructure
+
+Always use generic placeholders (e.g., `<your-endpoint>`, `<password>`) in documentation and examples. Real values belong exclusively in environment variables (`.env`, Vercel settings, etc.) which are gitignored.
+
+**Context:** This rule exists because a PostgreSQL URI was leaked via documentation committed to git, triggering a GitGuardian alert. This must never happen again.
+
 ## Architecture Diagrams
 
 Diagramas Mermaid da arquitetura estão em `ai_docs/diagrams/`. Consulte-os para entender a estrutura do projeto, relações entre entidades, fluxos de API e hierarquia de componentes.

--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -3,8 +3,8 @@
 ## The Problem
 
 We have two separate databases:
-- **DEV**: `ep-jolly-breeze-ahyfy0l4-pooler` (local development)
-- **PROD**: `ep-crimson-pond-ah4ykmjb-pooler` (Vercel production)
+- **DEV**: `ep-<dev-endpoint>-pooler` (local development)
+- **PROD**: `ep-<prod-endpoint>-pooler` (Vercel production)
 
 When schema changes are made and migrations are created locally, they only apply to the DEV database. The PROD database doesn't receive these changes automatically, causing 500 errors when the code tries to access tables that don't exist.
 
@@ -31,7 +31,7 @@ This ensures:
 
 In Vercel project settings → Environment Variables:
 - `DATABASE_URL` should point to the PROD database
-- This is already configured, but verify it matches: `ep-crimson-pond-ah4ykmjb-pooler`
+- This is already configured, but verify it matches your production Neon endpoint
 
 ## Migration Workflow
 
@@ -61,7 +61,7 @@ In Vercel project settings → Environment Variables:
 
 To manually apply migrations to PROD:
 ```bash
-DATABASE_URL="postgresql://...@ep-crimson-pond-ah4ykmjb-pooler.../neondb?sslmode=require" npx prisma migrate deploy
+DATABASE_URL="postgresql://<user>:<password>@<your-neon-endpoint>.neon.tech/neondb?sslmode=require" npx prisma migrate deploy
 ```
 
 ## Checklist Before Deploying Schema Changes


### PR DESCRIPTION
Remove real PostgreSQL endpoint identifiers from DATABASE_MIGRATIONS.md and add security rule to CLAUDE.md.