### PR TITLE
fix: extract rate limiter for Next.js route compat

### DIFF
--- a/src/app/api/bug-reports/route.ts
+++ b/src/app/api/bug-reports/route.ts
@@ -8,37 +8,7 @@ const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
 const MAX_IMAGES = 3;
 const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif"];
 
-// Rate limiting: max 5 bug reports per user per 15-minute window
-const RATE_LIMIT_MAX = 5;
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
-
-interface RateLimitEntry {
-  timestamps: number[];
-}
-
-export const rateLimitMap = new Map<string, RateLimitEntry>();
-
-function isRateLimited(userId: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
-
-  if (!entry) {
-    rateLimitMap.set(userId, { timestamps: [now] });
-    return false;
-  }
-
-  // Remove expired timestamps
-  entry.timestamps = entry.timestamps.filter(
-    (ts) => now - ts < RATE_LIMIT_WINDOW_MS
-  );
-
-  if (entry.timestamps.length >= RATE_LIMIT_MAX) {
-    return true;
-  }
-
-  entry.timestamps.push(now);
-  return false;
-}
+import { isRateLimited } from "@/lib/rate-limit";
 
 function getGitHubToken(): string | undefined {
   return process.env.GITHUB_TOKEN;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,34 @@
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+const rateLimitMap = new Map<string, RateLimitEntry>();
+
+export function isRateLimited(userId: string): boolean {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+
+  if (!entry) {
+    rateLimitMap.set(userId, { timestamps: [now] });
+    return false;
+  }
+
+  // Remove expired timestamps
+  entry.timestamps = entry.timestamps.filter(
+    (ts) => now - ts < RATE_LIMIT_WINDOW_MS
+  );
+
+  if (entry.timestamps.length >= RATE_LIMIT_MAX) {
+    return true;
+  }
+
+  entry.timestamps.push(now);
+  return false;
+}
+
+export function resetRateLimit() {
+  rateLimitMap.clear();
+}

--- a/tests/integration/api/bug-reports.test.ts
+++ b/tests/integration/api/bug-reports.test.ts
@@ -10,8 +10,9 @@ vi.stubEnv("GITHUB_TOKEN", "test-token");
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-// Import route after mocks are set up
-const { POST, rateLimitMap } = await import("@/app/api/bug-reports/route");
+// Import route and rate limit utility after mocks are set up
+const { POST } = await import("@/app/api/bug-reports/route");
+const { resetRateLimit } = await import("@/lib/rate-limit");
 
 function createFormData(fields: Record<string, string>, files?: { name: string; content: Buffer; type: string }[]) {
   const formData = new FormData();
@@ -66,7 +67,7 @@ function mockIssueAndProjectSuccess(issueNumber = 42) {
 describe("/api/bug-reports", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    rateLimitMap.clear();
+    resetRateLimit();
     (getAuthenticatedUserId as ReturnType<typeof vi.fn>).mockResolvedValue("user-1");
   });
 


### PR DESCRIPTION
## Summary
- Fixes Vercel build failure: Next.js disallows non-standard exports (`rateLimitMap`) from route files
- Extracts rate limiting logic to `src/lib/rate-limit.ts`

Follow-up to PR #18.