### PR TITLE
fix(installments): create only remaining installments when starting > 1

### DIFF
--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -129,6 +129,7 @@ export async function POST(request: NextRequest) {
       categoryId,
       isFixed,
       isInstallment,
+      currentInstallment: startInstallment,
       totalInstallments,
       installmentAmount,
       tags,
@@ -157,14 +158,17 @@ export async function POST(request: NextRequest) {
 
       const transactions = [];
       const startDate = parseDateLocal(date);
+      const firstInstallment = startInstallment && startInstallment > 1 ? startInstallment : 1;
+      const installmentsToCreate = totalInstallments - firstInstallment + 1;
 
-      for (let i = 0; i < totalInstallments; i++) {
+      for (let i = 0; i < installmentsToCreate; i++) {
+        const installmentNumber = firstInstallment + i;
         const transactionDate = new Date(startDate);
         transactionDate.setMonth(transactionDate.getMonth() + i);
 
         const transaction = await prisma.transaction.create({
           data: {
-            description: `${description} (${i + 1}/${totalInstallments})`,
+            description: `${description} (${installmentNumber}/${totalInstallments})`,
             amount: type === "EXPENSE" ? -Math.abs(installmentAmount || amount) : Math.abs(installmentAmount || amount),
             date: transactionDate,
             type,
@@ -173,7 +177,7 @@ export async function POST(request: NextRequest) {
             isFixed: false,
             isInstallment: true,
             installmentId: installment.id,
-            currentInstallment: i + 1,
+            currentInstallment: installmentNumber,
             tags: processedTags,
             userId,
           },

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -120,7 +120,7 @@ export function TransactionForm({
         description: transaction
           ? "Transação atualizada com sucesso"
           : isInstallment
-          ? `${totalInstallments} parcelas criadas com sucesso`
+          ? `${parseInt(totalInstallments) - parseInt(currentInstallment) + 1} parcelas criadas com sucesso`
           : "Transação criada com sucesso",
       });
 
@@ -310,7 +310,9 @@ export function TransactionForm({
             </div>
             {!transaction && (
               <p className="col-span-2 text-xs text-gray-500">
-                Serão criadas {totalInstallments} parcelas de{" "}
+                {parseInt(currentInstallment) > 1
+                  ? `Serão criadas ${parseInt(totalInstallments) - parseInt(currentInstallment) + 1} parcelas (${currentInstallment}/${totalInstallments} a ${totalInstallments}/${totalInstallments}) de `
+                  : `Serão criadas ${totalInstallments} parcelas de `}
                 {amount
                   ? new Intl.NumberFormat("pt-BR", {
                       style: "currency",

--- a/tests/integration/api/transactions.test.ts
+++ b/tests/integration/api/transactions.test.ts
@@ -374,6 +374,106 @@ describe('POST /api/transactions', () => {
     expect(mockPrisma.transaction.create).toHaveBeenCalledTimes(10)
   })
 
+  it('should create only remaining installments when currentInstallment > 1', async () => {
+    const mockInstallment = {
+      id: 'inst-2',
+      description: 'Smartphone',
+      totalAmount: 6000,
+      totalInstallments: 12,
+      installmentAmount: 500
+    }
+
+    const mockTransaction = {
+      id: 'txn-inst-11',
+      description: 'Smartphone (11/12)',
+      amount: -500,
+      installmentId: 'inst-2',
+      currentInstallment: 11,
+      installment: mockInstallment
+    }
+
+    mockPrisma.installment.create.mockResolvedValue(mockInstallment)
+    mockPrisma.transaction.create.mockResolvedValue(mockTransaction)
+
+    const request = createRequest('http://localhost:3000/api/transactions', {
+      method: 'POST',
+      body: JSON.stringify({
+        description: 'Smartphone',
+        amount: 500,
+        date: '2024-01-15',
+        type: 'EXPENSE',
+        origin: 'Nubank',
+        isInstallment: true,
+        currentInstallment: 11,
+        totalInstallments: 12
+      })
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(201)
+    expect(mockPrisma.installment.create).toHaveBeenCalled()
+    // Should create only 2 transactions (installments 11 and 12)
+    expect(mockPrisma.transaction.create).toHaveBeenCalledTimes(2)
+
+    // Verify first transaction is installment 11
+    const firstCall = mockPrisma.transaction.create.mock.calls[0][0]
+    expect(firstCall.data.currentInstallment).toBe(11)
+    expect(firstCall.data.description).toBe('Smartphone (11/12)')
+
+    // Verify second transaction is installment 12
+    const secondCall = mockPrisma.transaction.create.mock.calls[1][0]
+    expect(secondCall.data.currentInstallment).toBe(12)
+    expect(secondCall.data.description).toBe('Smartphone (12/12)')
+  })
+
+  it('should create all installments when currentInstallment is 1 (default)', async () => {
+    const mockInstallment = {
+      id: 'inst-3',
+      description: 'Notebook',
+      totalAmount: 3000,
+      totalInstallments: 3,
+      installmentAmount: 1000
+    }
+
+    const mockTransaction = {
+      id: 'txn-inst-1',
+      description: 'Notebook (1/3)',
+      amount: -1000,
+      installmentId: 'inst-3',
+      currentInstallment: 1,
+      installment: mockInstallment
+    }
+
+    mockPrisma.installment.create.mockResolvedValue(mockInstallment)
+    mockPrisma.transaction.create.mockResolvedValue(mockTransaction)
+
+    const request = createRequest('http://localhost:3000/api/transactions', {
+      method: 'POST',
+      body: JSON.stringify({
+        description: 'Notebook',
+        amount: 1000,
+        date: '2024-01-15',
+        type: 'EXPENSE',
+        origin: 'Nubank',
+        isInstallment: true,
+        currentInstallment: 1,
+        totalInstallments: 3
+      })
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(201)
+    // Should create all 3 transactions
+    expect(mockPrisma.transaction.create).toHaveBeenCalledTimes(3)
+
+    // Verify installment numbers 1, 2, 3
+    expect(mockPrisma.transaction.create.mock.calls[0][0].data.currentInstallment).toBe(1)
+    expect(mockPrisma.transaction.create.mock.calls[1][0].data.currentInstallment).toBe(2)
+    expect(mockPrisma.transaction.create.mock.calls[2][0].data.currentInstallment).toBe(3)
+  })
+
   it('should handle tags as array', async () => {
     mockPrisma.transaction.create.mockResolvedValue({
       id: 'txn-1',


### PR DESCRIPTION
## Summary

- When creating an installment starting at a number other than 1 (e.g., 11/12), the API now creates only the remaining installments instead of all from 1
- Updated frontend preview text to show the actual number of installments to be created and their range
- Added integration tests for both starting > 1 and starting at 1 (backward compatibility)

Closes #27

## Test plan

- [x] Integration test: creating installment 11/12 creates only 2 transactions (11 and 12)
- [x] Integration test: creating installment 1/3 creates all 3 transactions (backward compatible)
- [x] All 283 unit tests pass
- [x] No new integration test failures (4 pre-existing failures unrelated to this change)