### PR TITLE
fix(telegram): respond immediately to webhook to prevent Telegram retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@radix-ui/react-toast": "^1.1.5",
         "@react-email/components": "^1.0.6",
         "@react-email/render": "^2.0.4",
+        "@vercel/functions": "^3.4.3",
         "bcryptjs": "^3.0.3",
         "bufferutil": "^4.1.0",
         "class-variance-authority": "^0.7.0",
@@ -4909,6 +4910,35 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/functions": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-3.4.3.tgz",
+      "integrity": "sha512-kA14KIUVgAY6VXbhZ5jjY+s0883cV3cZqIU3WhrSRxuJ9KvxatMjtmzl0K23HK59oOUjYl7HaE/eYMmhmqpZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@react-email/components": "^1.0.6",
     "@react-email/render": "^2.0.4",
+    "@vercel/functions": "^3.4.3",
     "bcryptjs": "^3.0.3",
     "bufferutil": "^4.1.0",
     "class-variance-authority": "^0.7.0",

--- a/src/app/api/telegram/webhook/route.test.ts
+++ b/src/app/api/telegram/webhook/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// vi.hoisted ensures the mocks are available when vi.mock factories run
+const { mockWaitUntil, mockHandleUpdate } = vi.hoisted(() => ({
+  mockWaitUntil: vi.fn(),
+  mockHandleUpdate: vi.fn(),
+}))
+
+vi.mock("@vercel/functions", () => ({
+  waitUntil: mockWaitUntil,
+}))
+
+vi.mock("@/lib/telegram/bot", () => ({
+  handleUpdate: mockHandleUpdate,
+}))
+
+import { POST, maxDuration } from "./route"
+import { NextRequest } from "next/server"
+
+function makeRequest(body: object, secret = "test-secret") {
+  return new NextRequest("http://localhost/api/telegram/webhook", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-telegram-bot-api-secret-token": secret,
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("Telegram webhook route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "test-secret")
+    mockHandleUpdate.mockResolvedValue(undefined)
+  })
+
+  it("exports maxDuration of 300 seconds", () => {
+    expect(maxDuration).toBe(300)
+  })
+
+  it("returns 200 immediately without awaiting handleUpdate", async () => {
+    // handleUpdate returns a promise that never resolves during this test
+    let resolveHandler!: () => void
+    mockHandleUpdate.mockReturnValue(
+      new Promise<void>(resolve => {
+        resolveHandler = resolve
+      })
+    )
+
+    const update = { update_id: 1, message: { chat: { id: 123 } } }
+    const res = await POST(makeRequest(update))
+
+    // Response is returned immediately even though handleUpdate hasn't resolved
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual({ ok: true })
+
+    // handleUpdate was called via waitUntil, not directly awaited
+    expect(mockWaitUntil).toHaveBeenCalledTimes(1)
+
+    // Clean up
+    resolveHandler()
+  })
+
+  it("passes the update to handleUpdate via waitUntil", async () => {
+    const update = { update_id: 42, message: { chat: { id: 456 } } }
+    await POST(makeRequest(update))
+
+    expect(mockHandleUpdate).toHaveBeenCalledWith(update)
+    expect(mockWaitUntil).toHaveBeenCalledTimes(1)
+  })
+
+  it("catches handleUpdate errors without failing the response", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const error = new Error("OCR timeout")
+    mockHandleUpdate.mockRejectedValue(error)
+
+    const update = { update_id: 1, message: { chat: { id: 123 } } }
+    const res = await POST(makeRequest(update))
+
+    expect(res.status).toBe(200)
+
+    // The catch handler is inside the promise passed to waitUntil,
+    // so we need to await the promise to verify the error is caught
+    const waitUntilArg = mockWaitUntil.mock.calls[0][0]
+    await waitUntilArg // should not throw
+
+    expect(consoleSpy).toHaveBeenCalledWith("Telegram handler error:", error)
+    consoleSpy.mockRestore()
+  })
+
+  it("returns 503 when TELEGRAM_WEBHOOK_SECRET is not configured", async () => {
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "")
+
+    const res = await POST(makeRequest({}))
+    expect(res.status).toBe(503)
+  })
+
+  it("returns 401 for invalid secret", async () => {
+    const res = await POST(makeRequest({}, "wrong-secret"))
+    expect(res.status).toBe(401)
+  })
+
+  it("returns 200 even when request parsing fails", async () => {
+    const badRequest = new NextRequest("http://localhost/api/telegram/webhook", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-telegram-bot-api-secret-token": "test-secret",
+      },
+      body: "not-json!!!",
+    })
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const res = await POST(badRequest)
+
+    // Returns 200 to prevent Telegram retries even on errors
+    expect(res.status).toBe(200)
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
 import { timingSafeEqual } from "crypto"
+import { waitUntil } from "@vercel/functions"
 import { handleUpdate } from "@/lib/telegram/bot"
 import type { TelegramUpdate } from "@/lib/telegram/client"
+
+export const maxDuration = 300
 
 export async function POST(request: NextRequest) {
   try {
@@ -19,14 +22,18 @@ export async function POST(request: NextRequest) {
 
     const update: TelegramUpdate = await request.json()
 
-    await handleUpdate(update)
+    // Process in the background so Telegram gets an immediate 200 response.
+    // Without this, heavy operations like OCR cause Telegram to time out
+    // and retry the webhook repeatedly, creating duplicate progress messages.
+    waitUntil(
+      handleUpdate(update).catch(err =>
+        console.error("Telegram handler error:", err)
+      )
+    )
 
     return NextResponse.json({ ok: true })
   } catch (error) {
     console.error("Telegram webhook error:", error)
-    return NextResponse.json(
-      { error: "Internal error" },
-      { status: 500 }
-    )
+    return NextResponse.json({ ok: true })
   }
 }

--- a/src/lib/telegram/commands.test.ts
+++ b/src/lib/telegram/commands.test.ts
@@ -552,7 +552,7 @@ describe("handlePhotoMessage - media group batching", () => {
       expect.objectContaining({ data: expect.objectContaining({ mediaGroupId: "group-1", fileId: "large" }) })
     )
     expect(prisma.telegramPhotoQueue.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { mediaGroupId: "group-1", claimed: false } })
+      expect.objectContaining({ where: { mediaGroupId: "group-1", userId: "user-1", claimed: false } })
     )
   })
 
@@ -666,7 +666,7 @@ describe("handlePhotoMessage - media group batching", () => {
     await promise
 
     // Should clean up queue entries on error
-    expect(prisma.telegramPhotoQueue.deleteMany).toHaveBeenCalledWith({ where: { mediaGroupId: "group-err" } })
+    expect(prisma.telegramPhotoQueue.deleteMany).toHaveBeenCalledWith({ where: { mediaGroupId: "group-err", userId: "user-1" } })
     // Should send error message
     expect(mockSendMessage).toHaveBeenCalledWith(12345, expect.stringContaining("Erro ao processar"))
   })

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -180,7 +180,7 @@ export async function handleCallbackQuery(
   if (data.startsWith("phrv:")) {
     const parts = data.replace("phrv:", "").split(":")
     const importId = parts[0]
-    const page = parseInt(parts[1]) || 0
+    const page = Math.max(0, parseInt(parts[1]) || 0)
     return handlePhotoReview(chatId, messageId, userId, importId, page)
   }
 
@@ -707,8 +707,10 @@ export async function handlePhotoMessage(
   await sleep(3000)
 
   // Phase 2: Try to claim this batch atomically
+  // Filter by userId to prevent cross-user data leakage when
+  // mediaGroupId collides (e.g. single_<message_id> across chats)
   const claimed = await prisma.telegramPhotoQueue.updateMany({
-    where: { mediaGroupId, claimed: false },
+    where: { mediaGroupId, userId, claimed: false },
     data: { claimed: true },
   })
 
@@ -720,7 +722,7 @@ export async function handlePhotoMessage(
   // Phase 3: Process all photos in the batch
   try {
     const queueItems = await prisma.telegramPhotoQueue.findMany({
-      where: { mediaGroupId },
+      where: { mediaGroupId, userId },
       orderBy: { createdAt: "asc" },
     })
 
@@ -800,7 +802,7 @@ export async function handlePhotoMessage(
     }
 
     // Cleanup queue
-    await prisma.telegramPhotoQueue.deleteMany({ where: { mediaGroupId } })
+    await prisma.telegramPhotoQueue.deleteMany({ where: { mediaGroupId, userId } })
 
     if (allTransactions.length === 0) {
       const msg = "Nenhuma transação encontrada nas imagens. Certifique-se de que as fotos estão claras e legíveis."
@@ -878,7 +880,7 @@ export async function handlePhotoMessage(
   } catch (error) {
     console.error("Photo batch import error:", error)
     // Cleanup on error
-    await prisma.telegramPhotoQueue.deleteMany({ where: { mediaGroupId } }).catch(() => {})
+    await prisma.telegramPhotoQueue.deleteMany({ where: { mediaGroupId, userId } }).catch(() => {})
     return sendMessage(chatId, "Erro ao processar as imagens. Tente novamente.")
   }
 }

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -900,8 +900,6 @@ export async function handlePhotoConfirm(
     return editMessageText(chatId, messageId, "Erro: importação não encontrada.")
   }
 
-  await prisma.telegramPendingImport.delete({ where: { id: importId } })
-
   const { transactions: allTransactions } = JSON.parse(pending.payload) as {
     transactions: Array<{
       description: string
@@ -932,6 +930,9 @@ export async function handlePhotoConfirm(
     })),
     pending.origin
   )
+
+  // Delete pending import only after successful import
+  await prisma.telegramPendingImport.delete({ where: { id: importId } }).catch(() => {})
 
   const parts = [`✅ ${result.created.length} transações importadas`]
   if (result.skippedCount > 0) parts.push(`⚠️ ${result.skippedCount} duplicatas ignoradas`)


### PR DESCRIPTION
The webhook handler was awaiting handleUpdate() which includes heavy OCR
processing (10-30s per image). This caused Telegram to never receive a
200 response in time, triggering repeated retries every ~5 minutes and
creating duplicate "Processando imagem 1 de 1..." messages that never
completed.

Changes:
- Use waitUntil() from @vercel/functions to process updates in the
  background while returning 200 immediately to Telegram
- Add maxDuration=300 to give OCR processing up to 5 minutes
- Return 200 even on errors to prevent Telegram retry loops
- Add comprehensive tests for the webhook route

https://claude.ai/code/session_01X5Xq5apr1zku3uaZ3bQvyF