### PR TITLE
fix(ocr): suporte a fatura de cartão Nubank (PDF) e Itaú (screenshot)

### DIFF
--- a/src/app/recurring/page.test.tsx
+++ b/src/app/recurring/page.test.tsx
@@ -78,8 +78,9 @@ describe('RecurringPage - total value display', () => {
       expect(screen.queryByText('Carregando...')).toBeNull()
     })
 
-    // Total should be 120 + 30 = 150 (excluding inactive 50)
-    expect(screen.getByText('R$ 150,00')).toBeInTheDocument()
+    // Total (120 + 30 = 150) is shown in both the "Previsto" stats card and
+    // the bottom "Total:" header — assert at least one instance exists.
+    expect(screen.getAllByText('R$ 150,00').length).toBeGreaterThan(0)
   })
 
   it('shows income total when there are active income items', async () => {
@@ -95,9 +96,9 @@ describe('RecurringPage - total value display', () => {
       expect(screen.queryByText('Carregando...')).toBeNull()
     })
 
-    expect(screen.getByText('R$ 100,00')).toBeInTheDocument()
+    expect(screen.getAllByText('R$ 100,00').length).toBeGreaterThan(0)
     expect(screen.getByText('Receita:')).toBeInTheDocument()
-    expect(screen.getByText('R$ 5.000,00')).toBeInTheDocument()
+    expect(screen.getAllByText('R$ 5.000,00').length).toBeGreaterThan(0)
   })
 
   it('does not show income label when no active income items exist', async () => {
@@ -113,7 +114,7 @@ describe('RecurringPage - total value display', () => {
       expect(screen.queryByText('Carregando...')).toBeNull()
     })
 
-    expect(screen.getByText('R$ 100,00')).toBeInTheDocument()
+    expect(screen.getAllByText('R$ 100,00').length).toBeGreaterThan(0)
     expect(screen.queryByText('Receita:')).not.toBeInTheDocument()
   })
 

--- a/src/components/SpaceSwitcher.test.tsx
+++ b/src/components/SpaceSwitcher.test.tsx
@@ -20,6 +20,36 @@ const mockMemberships = [
   },
 ]
 
+// The component calls two endpoints in parallel: /api/spaces and
+// /api/spaces/active/permissions. Route responses by URL so tests don't
+// have to care about resolution order.
+function mockSpacesApi(options: {
+  spaces?: unknown
+  spacesOk?: boolean
+  permissions?: unknown
+  permissionsOk?: boolean
+} = {}) {
+  const {
+    spaces = mockMemberships,
+    spacesOk = true,
+    permissions = { isSpaceContext: false, spaceId: null },
+    permissionsOk = true,
+  } = options
+
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/spaces') {
+      return Promise.resolve({ ok: spacesOk, json: () => Promise.resolve(spaces) })
+    }
+    if (url === '/api/spaces/active/permissions') {
+      return Promise.resolve({ ok: permissionsOk, json: () => Promise.resolve(permissions) })
+    }
+    if (url === '/api/spaces/active') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+}
+
 describe('SpaceSwitcher', () => {
   beforeEach(() => {
     mockFetch.mockReset()
@@ -27,10 +57,7 @@ describe('SpaceSwitcher', () => {
   })
 
   it('renders nothing when user has no spaces', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve([]),
-    })
+    mockSpacesApi({ spaces: [] })
 
     const { container } = render(<SpaceSwitcher />)
 
@@ -40,10 +67,7 @@ describe('SpaceSwitcher', () => {
   })
 
   it('renders switcher when user has spaces', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMemberships),
-    })
+    mockSpacesApi()
 
     render(<SpaceSwitcher />)
 
@@ -53,10 +77,7 @@ describe('SpaceSwitcher', () => {
   })
 
   it('shows personal account as default label', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(mockMemberships),
-    })
+    mockSpacesApi()
 
     render(<SpaceSwitcher />)
 
@@ -66,15 +87,7 @@ describe('SpaceSwitcher', () => {
   })
 
   it('switches to space when clicked', async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockMemberships),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ activeSpaceId: 'space-1' }),
-      })
+    mockSpacesApi()
 
     render(<SpaceSwitcher />)
 
@@ -101,10 +114,7 @@ describe('SpaceSwitcher', () => {
   })
 
   it('handles fetch error gracefully', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      json: () => Promise.resolve({ error: 'Unauthorized' }),
-    })
+    mockSpacesApi({ spacesOk: false, spaces: { error: 'Unauthorized' } })
 
     const { container } = render(<SpaceSwitcher />)
 

--- a/src/lib/statement-parser.test.ts
+++ b/src/lib/statement-parser.test.ts
@@ -332,6 +332,85 @@ login com sua conta Nubank.`;
   });
 });
 
+describe("Itaú credit card invoice parsing (screenshot OCR)", () => {
+  // Real Tesseract output from an Itaú open-invoice screenshot (2026-04-19)
+  const ITAU_INVOICE_OCR_TEXT = `18:45 all FS
+< O)
+ontem, 18 de abril
+BP lojas americanas R$ 85,75 y
+cartão físico em 2x
+16 de abril
+99*
+CC) ao R$13,50 >
+cartão físico
+15 de abril
+torii
+ER e R$10,00 >
+cartão físico
+ferragens padak
+CC) 2gemsP R$18,90 >
+cartão físico
+6 shopee *lojapexin R$ 40,79 y
+cartão virtual em 2x
+10 de abril
+E shopee *girusmov R$ 170,70 y
+cartão virtual em 3x
+conta vivo
+C) ie o R$99,99 >
+cartão virtual`;
+
+  it("extracts all 7 transactions", () => {
+    const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
+    expect(result.transactions.length).toBe(7);
+  });
+
+  it("sets bank as Fatura Itaú", () => {
+    const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
+    expect(result.bank).toBe("Fatura Itaú");
+  });
+
+  it("uses pending description line when amount line is OCR-garbled", () => {
+    const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
+    const descriptions = result.transactions.map((t) => t.description);
+    expect(descriptions).toContain("99*");
+    expect(descriptions).toContain("torii");
+    expect(descriptions).toContain("ferragens padak");
+    expect(descriptions).toContain("conta vivo");
+  });
+
+  it("strips leading icon noise from inline descriptions", () => {
+    const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
+    const descriptions = result.transactions.map((t) => t.description);
+    expect(descriptions).toContain("lojas americanas");
+    expect(descriptions).toContain("shopee *lojapexin");
+    expect(descriptions).toContain("shopee *girusmov");
+  });
+
+  it("parses amounts as EXPENSE with correct values", () => {
+    const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
+    const americanas = result.transactions.find((t) => t.description === "lojas americanas");
+    expect(americanas?.amount).toBe(-85.75);
+    expect(americanas?.type).toBe("EXPENSE");
+
+    const vivo = result.transactions.find((t) => t.description === "conta vivo");
+    expect(vivo?.amount).toBe(-99.99);
+
+    const girusmov = result.transactions.find((t) => t.description === "shopee *girusmov");
+    expect(girusmov?.amount).toBe(-170.70);
+  });
+
+  it("parses DD de MONTH date headers with correct year (2026)", () => {
+    const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
+    const apr18 = result.transactions.find((t) => t.description === "lojas americanas");
+    expect(apr18?.date.getDate()).toBe(18);
+    expect(apr18?.date.getMonth()).toBe(3); // April
+
+    const apr10 = result.transactions.find((t) => t.description === "shopee *girusmov");
+    expect(apr10?.date.getDate()).toBe(10);
+    expect(apr10?.date.getMonth()).toBe(3);
+  });
+});
+
 describe("C6 credit card invoice parsing (screenshot OCR)", () => {
   // Real OCR output from C6 credit card screenshot
   const C6_CARD_OCR_TEXT = `08:51 SED

--- a/src/lib/statement-parser.test.ts
+++ b/src/lib/statement-parser.test.ts
@@ -242,33 +242,35 @@ Resgate RDB
 });
 
 describe("Nubank credit card invoice parsing (PDF)", () => {
-  // Real text extracted by unpdf from a Nubank credit card invoice PDF
-  const NUBANK_INVOICE_PDF_TEXT = `RAISSA SINDEAUX DE LIMA
+  // Fictional fixture modeled after the Nubank invoice PDF layout produced by unpdf.
+  // Structure is preserved (headers, section markers, "DD MMM •••• NNNN" lines)
+  // so the parser logic is exercised, but all names/merchants/amounts are made up.
+  const NUBANK_INVOICE_PDF_TEXT = `TITULAR FICTICIO
 FATURA 13 ABR 2026 EMISSÃO E ENVIO 04 ABR 2026
 RESUMO DA FATURA ATUAL
-Fatura anterior R$ 891,67
-Pagamento recebido −R$ 891,67
-Total de compras de todos os cartões, 04 MAR a 04 ABR R$ 567,61
-Outros lançamentos R$ 21,44
-Total a pagar R$ 589,05
-Pagamento mínimo para não ficar em atraso R$ 106,58
+Fatura anterior R$ 100,00
+Pagamento recebido −R$ 100,00
+Total de compras de todos os cartões, 04 MAR a 04 ABR R$ 500,00
+Outros lançamentos R$ 10,00
+Total a pagar R$ 510,00
+Pagamento mínimo para não ficar em atraso R$ 100,00
 PRÓXIMAS FATURAS
 Fechamento da próxima fatura 04 MAI 2026
 TRANSAÇÕES DE 04 MAR A 04 ABR
-Raissa S Lima R$ 567,61
-04 MAR •••• 3746 Odp-Outlet D*Odptech - Parcela 2/2 R$ 31,78
-04 MAR •••• 3746 Shein *Shein.Com - Parcela 5/6 R$ 63,50
-05 MAR •••• 3746 Mercadolivre*2produto R$ 163,73
-11 MAR •••• 3746 Applecombill R$ 5,90
-17 MAR •••• 3746 Cobasi R$ 63,80
-21 MAR •••• 1747 Lojas Americanas R$ 14,76
-23 MAR •••• 3746 Amazon R$ 56,81
-23 MAR •••• 3746 Amazon R$ 6,47
-23 MAR •••• 3746 Amazon R$ 33,32
-01 ABR •••• 1747 Uber Uber *Trip Help.U R$ 116,04
-02 ABR •••• 3746 Jjlanches R$ 11,50
-Pagamentos e Financiamentos -R$ 870,22
-13 MAR Pagamento em 13 MAR −R$ 891,67
+Titular Fict R$ 500,00
+04 MAR •••• 1111 Loja A - Parcela 2/2 R$ 10,00
+04 MAR •••• 1111 Loja B - Parcela 5/6 R$ 20,00
+05 MAR •••• 1111 Loja C R$ 30,00
+11 MAR •••• 1111 Servico X R$ 40,00
+17 MAR •••• 1111 Servico Y R$ 50,00
+21 MAR •••• 2222 Loja D R$ 60,00
+23 MAR •••• 1111 Loja E R$ 70,00
+23 MAR •••• 1111 Loja E R$ 80,00
+23 MAR •••• 1111 Loja E R$ 90,00
+01 ABR •••• 2222 Transporte F R$ 40,00
+02 ABR •••• 1111 Restaurante G R$ 10,00
+Pagamentos e Financiamentos -R$ 100,00
+13 MAR Pagamento em 13 MAR −R$ 100,00
 13 MAR Juros de dívida encerrada R$ 0,67
 login com sua conta Nubank.`;
 
@@ -285,25 +287,21 @@ login com sua conta Nubank.`;
   it("parses descriptions without card number noise", () => {
     const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
     const descriptions = result.transactions.map((t) => t.description);
-    expect(descriptions).toContain("Odp-Outlet D*Odptech - Parcela 2/2");
-    expect(descriptions).toContain("Shein *Shein.Com - Parcela 5/6");
-    expect(descriptions).toContain("Mercadolivre*2produto");
-    expect(descriptions).toContain("Uber Uber *Trip Help.U");
+    expect(descriptions).toContain("Loja A - Parcela 2/2");
+    expect(descriptions).toContain("Loja B - Parcela 5/6");
+    expect(descriptions).toContain("Loja C");
+    expect(descriptions).toContain("Transporte F");
   });
 
   it("parses amounts as negative (EXPENSE) for purchases", () => {
     const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
-    const netflix = result.transactions.find((t) =>
-      t.description.startsWith("Applecombill")
-    );
-    expect(netflix?.amount).toBe(-5.9);
-    expect(netflix?.type).toBe("EXPENSE");
+    const servicoX = result.transactions.find((t) => t.description === "Servico X");
+    expect(servicoX?.amount).toBe(-40);
+    expect(servicoX?.type).toBe("EXPENSE");
 
-    const uber = result.transactions.find((t) =>
-      t.description.startsWith("Uber")
-    );
-    expect(uber?.amount).toBe(-116.04);
-    expect(uber?.type).toBe("EXPENSE");
+    const transporte = result.transactions.find((t) => t.description === "Transporte F");
+    expect(transporte?.amount).toBe(-40);
+    expect(transporte?.type).toBe("EXPENSE");
   });
 
   it("uses invoice FATURA date to infer transaction year", () => {
@@ -322,22 +320,24 @@ login com sua conta Nubank.`;
 
   it("keeps duplicate merchants on same day with different amounts", () => {
     const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
-    // Three Amazon purchases on 23 MAR with different amounts
-    const amazons = result.transactions.filter(
-      (t) => t.description === "Amazon" && t.date.getDate() === 23
+    const lojaE = result.transactions.filter(
+      (t) => t.description === "Loja E" && t.date.getDate() === 23
     );
-    expect(amazons.length).toBe(3);
-    const amounts = amazons.map((t) => Math.abs(t.amount)).sort((a, b) => a - b);
-    expect(amounts).toEqual([6.47, 33.32, 56.81]);
+    expect(lojaE.length).toBe(3);
+    const amounts = lojaE.map((t) => Math.abs(t.amount)).sort((a, b) => a - b);
+    expect(amounts).toEqual([70, 80, 90]);
   });
 });
 
 describe("Itaú credit card invoice parsing (screenshot OCR)", () => {
-  // Real Tesseract output from an Itaú open-invoice screenshot (2026-04-19)
+  // Fictional fixture modeled after Tesseract output for an Itaú open-invoice
+  // screenshot. Layout is preserved (status bar, "DD de MONTH" headers,
+  // "cartão físico/virtual" sub-labels, garbled icon tokens before amount),
+  // but all merchants/amounts are made up.
   const ITAU_INVOICE_OCR_TEXT = `18:45 all FS
 < O)
 ontem, 18 de abril
-BP lojas americanas R$ 85,75 y
+BP loja alpha R$ 85,75 y
 cartão físico em 2x
 16 de abril
 99*
@@ -347,15 +347,15 @@ cartão físico
 torii
 ER e R$10,00 >
 cartão físico
-ferragens padak
+loja beta
 CC) 2gemsP R$18,90 >
 cartão físico
-6 shopee *lojapexin R$ 40,79 y
+6 servico gama R$ 40,79 y
 cartão virtual em 2x
 10 de abril
-E shopee *girusmov R$ 170,70 y
+E servico delta R$ 170,70 y
 cartão virtual em 3x
-conta vivo
+conta teste
 C) ie o R$99,99 >
 cartão virtual`;
 
@@ -374,38 +374,38 @@ cartão virtual`;
     const descriptions = result.transactions.map((t) => t.description);
     expect(descriptions).toContain("99*");
     expect(descriptions).toContain("torii");
-    expect(descriptions).toContain("ferragens padak");
-    expect(descriptions).toContain("conta vivo");
+    expect(descriptions).toContain("loja beta");
+    expect(descriptions).toContain("conta teste");
   });
 
   it("strips leading icon noise from inline descriptions", () => {
     const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
     const descriptions = result.transactions.map((t) => t.description);
-    expect(descriptions).toContain("lojas americanas");
-    expect(descriptions).toContain("shopee *lojapexin");
-    expect(descriptions).toContain("shopee *girusmov");
+    expect(descriptions).toContain("loja alpha");
+    expect(descriptions).toContain("servico gama");
+    expect(descriptions).toContain("servico delta");
   });
 
   it("parses amounts as EXPENSE with correct values", () => {
     const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
-    const americanas = result.transactions.find((t) => t.description === "lojas americanas");
-    expect(americanas?.amount).toBe(-85.75);
-    expect(americanas?.type).toBe("EXPENSE");
+    const alpha = result.transactions.find((t) => t.description === "loja alpha");
+    expect(alpha?.amount).toBe(-85.75);
+    expect(alpha?.type).toBe("EXPENSE");
 
-    const vivo = result.transactions.find((t) => t.description === "conta vivo");
-    expect(vivo?.amount).toBe(-99.99);
+    const teste = result.transactions.find((t) => t.description === "conta teste");
+    expect(teste?.amount).toBe(-99.99);
 
-    const girusmov = result.transactions.find((t) => t.description === "shopee *girusmov");
-    expect(girusmov?.amount).toBe(-170.70);
+    const delta = result.transactions.find((t) => t.description === "servico delta");
+    expect(delta?.amount).toBe(-170.70);
   });
 
   it("parses DD de MONTH date headers with correct year (2026)", () => {
     const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
-    const apr18 = result.transactions.find((t) => t.description === "lojas americanas");
+    const apr18 = result.transactions.find((t) => t.description === "loja alpha");
     expect(apr18?.date.getDate()).toBe(18);
     expect(apr18?.date.getMonth()).toBe(3); // April
 
-    const apr10 = result.transactions.find((t) => t.description === "shopee *girusmov");
+    const apr10 = result.transactions.find((t) => t.description === "servico delta");
     expect(apr10?.date.getDate()).toBe(10);
     expect(apr10?.date.getMonth()).toBe(3);
   });

--- a/src/lib/statement-parser.test.ts
+++ b/src/lib/statement-parser.test.ts
@@ -241,6 +241,97 @@ Resgate RDB
   });
 });
 
+describe("Nubank credit card invoice parsing (PDF)", () => {
+  // Real text extracted by unpdf from a Nubank credit card invoice PDF
+  const NUBANK_INVOICE_PDF_TEXT = `RAISSA SINDEAUX DE LIMA
+FATURA 13 ABR 2026 EMISSÃO E ENVIO 04 ABR 2026
+RESUMO DA FATURA ATUAL
+Fatura anterior R$ 891,67
+Pagamento recebido −R$ 891,67
+Total de compras de todos os cartões, 04 MAR a 04 ABR R$ 567,61
+Outros lançamentos R$ 21,44
+Total a pagar R$ 589,05
+Pagamento mínimo para não ficar em atraso R$ 106,58
+PRÓXIMAS FATURAS
+Fechamento da próxima fatura 04 MAI 2026
+TRANSAÇÕES DE 04 MAR A 04 ABR
+Raissa S Lima R$ 567,61
+04 MAR •••• 3746 Odp-Outlet D*Odptech - Parcela 2/2 R$ 31,78
+04 MAR •••• 3746 Shein *Shein.Com - Parcela 5/6 R$ 63,50
+05 MAR •••• 3746 Mercadolivre*2produto R$ 163,73
+11 MAR •••• 3746 Applecombill R$ 5,90
+17 MAR •••• 3746 Cobasi R$ 63,80
+21 MAR •••• 1747 Lojas Americanas R$ 14,76
+23 MAR •••• 3746 Amazon R$ 56,81
+23 MAR •••• 3746 Amazon R$ 6,47
+23 MAR •••• 3746 Amazon R$ 33,32
+01 ABR •••• 1747 Uber Uber *Trip Help.U R$ 116,04
+02 ABR •••• 3746 Jjlanches R$ 11,50
+Pagamentos e Financiamentos -R$ 870,22
+13 MAR Pagamento em 13 MAR −R$ 891,67
+13 MAR Juros de dívida encerrada R$ 0,67
+login com sua conta Nubank.`;
+
+  it("extracts all 11 purchases from the invoice", () => {
+    const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
+    expect(result.transactions.length).toBe(11);
+  });
+
+  it("sets bank as Fatura Nubank", () => {
+    const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
+    expect(result.bank).toBe("Fatura Nubank");
+  });
+
+  it("parses descriptions without card number noise", () => {
+    const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
+    const descriptions = result.transactions.map((t) => t.description);
+    expect(descriptions).toContain("Odp-Outlet D*Odptech - Parcela 2/2");
+    expect(descriptions).toContain("Shein *Shein.Com - Parcela 5/6");
+    expect(descriptions).toContain("Mercadolivre*2produto");
+    expect(descriptions).toContain("Uber Uber *Trip Help.U");
+  });
+
+  it("parses amounts as negative (EXPENSE) for purchases", () => {
+    const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
+    const netflix = result.transactions.find((t) =>
+      t.description.startsWith("Applecombill")
+    );
+    expect(netflix?.amount).toBe(-5.9);
+    expect(netflix?.type).toBe("EXPENSE");
+
+    const uber = result.transactions.find((t) =>
+      t.description.startsWith("Uber")
+    );
+    expect(uber?.amount).toBe(-116.04);
+    expect(uber?.type).toBe("EXPENSE");
+  });
+
+  it("uses invoice FATURA date to infer transaction year", () => {
+    const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
+    // Invoice is FATURA 13 ABR 2026, so all transactions are 2026
+    const mar4 = result.transactions.find(
+      (t) => t.date.getDate() === 4 && t.date.getMonth() === 2
+    );
+    expect(mar4?.date.getFullYear()).toBe(2026);
+
+    const abr2 = result.transactions.find(
+      (t) => t.date.getDate() === 2 && t.date.getMonth() === 3
+    );
+    expect(abr2?.date.getFullYear()).toBe(2026);
+  });
+
+  it("keeps duplicate merchants on same day with different amounts", () => {
+    const result = parseStatementText(NUBANK_INVOICE_PDF_TEXT, 95);
+    // Three Amazon purchases on 23 MAR with different amounts
+    const amazons = result.transactions.filter(
+      (t) => t.description === "Amazon" && t.date.getDate() === 23
+    );
+    expect(amazons.length).toBe(3);
+    const amounts = amazons.map((t) => Math.abs(t.amount)).sort((a, b) => a - b);
+    expect(amounts).toEqual([6.47, 33.32, 56.81]);
+  });
+});
+
 describe("C6 credit card invoice parsing (screenshot OCR)", () => {
   // Real OCR output from C6 credit card screenshot
   const C6_CARD_OCR_TEXT = `08:51 SED

--- a/src/lib/statement-parser.test.ts
+++ b/src/lib/statement-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseStatementText, detectBank, isC6CreditCardInvoice, isCreditCardScreenshot, extractC6CreditCardTransactions, extractCreditCardScreenshotTransactions } from "./statement-parser";
+import { parseStatementText, detectBank, isC6CreditCardInvoice, isCreditCardScreenshot, extractC6CreditCardTransactions, extractCreditCardScreenshotTransactions, extractItauInvoiceTransactions } from "./statement-parser";
 
 describe("Nubank statement parsing", () => {
   const NUBANK_STATEMENT_TEXT = `
@@ -327,6 +327,63 @@ login com sua conta Nubank.`;
     const amounts = lojaE.map((t) => Math.abs(t.amount)).sort((a, b) => a - b);
     expect(amounts).toEqual([70, 80, 90]);
   });
+
+  it("treats refund (minus sign before R$) as INCOME", () => {
+    const text = `Titular Ficticio
+FATURA 13 ABR 2026
+Total a pagar R$ 100,00
+TRANSAÇÕES DE 04 MAR A 04 ABR
+Nubank
+15 MAR •••• 1111 Loja Z - Estorno −R$ 50,00
+20 MAR •••• 1111 Loja Z R$ 30,00`;
+    const result = parseStatementText(text, 95);
+    const estorno = result.transactions.find((t) => t.amount > 0);
+    expect(estorno).toBeDefined();
+    expect(estorno?.type).toBe("INCOME");
+    expect(estorno?.amount).toBe(50);
+  });
+
+  it("infers previous year for transactions after reference month (Dec -> Jan)", () => {
+    const text = `Titular Ficticio
+FATURA 10 JAN 2026
+Total a pagar R$ 100,00
+TRANSAÇÕES DE 10 DEZ A 10 JAN
+Nubank
+15 DEZ •••• 1111 Loja Natal R$ 150,00
+05 JAN •••• 1111 Loja Ano Novo R$ 200,00`;
+    const result = parseStatementText(text, 95);
+    expect(result.transactions.length).toBe(2);
+    const dez = result.transactions.find((t) => t.description === "Loja Natal");
+    expect(dez?.date.getFullYear()).toBe(2025);
+    expect(dez?.date.getMonth()).toBe(11); // December
+
+    const jan = result.transactions.find((t) => t.description === "Loja Ano Novo");
+    expect(jan?.date.getFullYear()).toBe(2026);
+    expect(jan?.date.getMonth()).toBe(0); // January
+  });
+
+  it("does not misclassify Nubank bank statement as invoice", () => {
+    const text = `
+Nu Financeira
+01 MAR 2026 Total de entradas + 500,00
+Transferência recebida pelo Pix JOAO TESTE
+500,00
+`;
+    const result = parseStatementText(text, 95);
+    expect(result.bank).toBe("Extrato Nubank");
+  });
+
+  it("matches purchase line with only 2 bullet chars (lenient OCR)", () => {
+    const text = `Titular Ficticio
+FATURA 13 ABR 2026
+Total a pagar R$ 100,00
+TRANSAÇÕES DE 04 MAR A 04 ABR
+Nubank
+15 MAR •• 1111 Loja OCR Garbled R$ 40,00`;
+    const result = parseStatementText(text, 95);
+    expect(result.transactions.length).toBe(1);
+    expect(result.transactions[0].description).toBe("Loja OCR Garbled");
+  });
 });
 
 describe("Itaú credit card invoice parsing (screenshot OCR)", () => {
@@ -399,7 +456,7 @@ cartão virtual`;
     expect(delta?.amount).toBe(-170.70);
   });
 
-  it("parses DD de MONTH date headers with correct year (2026)", () => {
+  it("parses DD de MONTH date headers with correct day and month", () => {
     const result = parseStatementText(ITAU_INVOICE_OCR_TEXT, 80);
     const apr18 = result.transactions.find((t) => t.description === "loja alpha");
     expect(apr18?.date.getDate()).toBe(18);
@@ -408,6 +465,41 @@ cartão virtual`;
     const apr10 = result.transactions.find((t) => t.description === "servico delta");
     expect(apr10?.date.getDate()).toBe(10);
     expect(apr10?.date.getMonth()).toBe(3);
+  });
+
+  it("uses explicit referenceDate to infer year deterministically", () => {
+    const reference = new Date(2026, 3, 19); // 19 April 2026
+    const txs = extractItauInvoiceTransactions(ITAU_INVOICE_OCR_TEXT, 80, reference);
+    const apr18 = txs.find((t) => t.description === "loja alpha");
+    expect(apr18?.date.getFullYear()).toBe(2026);
+    expect(apr18?.date.getMonth()).toBe(3);
+  });
+
+  it("infers previous year when transaction month is future of reference month", () => {
+    // Reference: 10 Feb 2026. A December entry must be from 2025.
+    const reference = new Date(2026, 1, 10);
+    const text = `15:00 all
+< O)
+15 de dezembro
+BP loja natal R$ 50,00
+cartão físico`;
+    const txs = extractItauInvoiceTransactions(text, 80, reference);
+    expect(txs).toHaveLength(1);
+    expect(txs[0].date.getFullYear()).toBe(2025);
+    expect(txs[0].date.getMonth()).toBe(11); // December
+  });
+
+  it("handles março with cedilla in date header", () => {
+    const reference = new Date(2026, 3, 19);
+    const text = `15:00 all
+< O)
+15 de março
+BP loja teste R$ 25,00
+cartão físico`;
+    const txs = extractItauInvoiceTransactions(text, 80, reference);
+    expect(txs).toHaveLength(1);
+    expect(txs[0].date.getMonth()).toBe(2); // March
+    expect(txs[0].date.getDate()).toBe(15);
   });
 });
 

--- a/src/lib/statement-parser.ts
+++ b/src/lib/statement-parser.ts
@@ -1048,6 +1048,130 @@ export function extractCreditCardScreenshotTransactions(
 // Keep old name as alias for backwards compatibility in tests
 export const extractC6CreditCardTransactions = extractCreditCardScreenshotTransactions;
 
+// ===== Nubank credit card invoice format (PDF) =====
+
+// Invoice header: "FATURA 13 ABR 2026" — used as year reference
+const NUBANK_INVOICE_HEADER_PATTERN =
+  /FATURA\s+(\d{1,2})\s+(JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+(\d{4})/i;
+
+// Purchase line: "04 MAR •••• 3746 Odp-Outlet D*Odptech - Parcela 2/2 R$ 31,78"
+// Captures: day, month, card4, description, amount (with optional minus sign)
+const NUBANK_INVOICE_PURCHASE_PATTERN =
+  /^(\d{1,2})\s+(JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+[•·\*]{3,}\s*(\d{4})\s+(.+?)\s+([−\-]?\s*R\$\s*[\d.,]+)\s*$/i;
+
+/**
+ * Detect if this is a Nubank credit card invoice PDF.
+ * Signals (need at least 2): Nubank brand + FATURA header / TRANSAÇÕES section /
+ * "Total a pagar" / purchase lines with "DD MMM •••• NNNN".
+ */
+function isNubankCreditCardInvoice(text: string): boolean {
+  const hasNubankRef =
+    /NUBANK/i.test(text) ||
+    /Nu\s*Pagamentos/i.test(text) ||
+    /Nu\s*Financeira/i.test(text);
+  if (!hasNubankRef) return false;
+
+  const hasInvoiceHeader = NUBANK_INVOICE_HEADER_PATTERN.test(text);
+  const hasTransactionSection =
+    /TRANSA[CÇ][OÕ]ES\s+DE\s+\d{1,2}\s+\w+\s+A\s+\d{1,2}\s+\w+/i.test(text);
+  const hasTotalAPagar = /Total\s+a\s+pagar/i.test(text);
+  const hasPurchaseLines =
+    /\d{1,2}\s+(?:JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+[•·\*]{3,}\s*\d{4}/i.test(
+      text
+    );
+
+  const signalCount = [
+    hasInvoiceHeader,
+    hasTransactionSection,
+    hasTotalAPagar,
+    hasPurchaseLines,
+  ].filter(Boolean).length;
+  return signalCount >= 2;
+}
+
+/**
+ * Extract invoice FATURA date (used to infer transaction year).
+ */
+function extractNubankInvoiceDate(text: string): Date | null {
+  const match = text.match(NUBANK_INVOICE_HEADER_PATTERN);
+  if (!match) return null;
+  const day = parseInt(match[1], 10);
+  const month = MONTH_ABBREV[match[2].toLowerCase()];
+  const year = parseInt(match[3], 10);
+  if (month === undefined) return null;
+  const date = new Date(year, month, day);
+  return isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Parse a single Nubank invoice purchase line.
+ */
+function parseNubankInvoicePurchase(
+  line: string,
+  referenceDate: Date,
+  confidence: number
+): StatementTransaction | null {
+  const match = line.match(NUBANK_INVOICE_PURCHASE_PATTERN);
+  if (!match) return null;
+
+  const day = parseInt(match[1], 10);
+  const month = MONTH_ABBREV[match[2].toLowerCase()];
+  if (month === undefined || day < 1 || day > 31) return null;
+
+  // Infer year: if transaction month > reference month, it's from previous year
+  // (e.g., invoice FATURA is JAN 2026, transaction is DEZ → DEZ 2025)
+  const refMonth = referenceDate.getMonth();
+  const refYear = referenceDate.getFullYear();
+  const year = month > refMonth ? refYear - 1 : refYear;
+
+  const date = new Date(year, month, day);
+  if (isNaN(date.getTime())) return null;
+
+  const description = match[4].trim();
+  if (description.length < 2) return null;
+
+  const amountStr = match[5];
+  const rawAmount = parseAmount(amountStr);
+  if (rawAmount === 0) return null;
+
+  // Minus sign (− U+2212 or - U+002D) before R$ indicates refund/estorno
+  const isNegative = /^\s*[−\-]/.test(amountStr);
+  const type: TransactionType = isNegative ? "INCOME" : "EXPENSE";
+
+  return {
+    date,
+    description,
+    amount: type === "EXPENSE" ? -Math.abs(rawAmount) : Math.abs(rawAmount),
+    type,
+    confidence,
+  };
+}
+
+/**
+ * Extract purchase transactions from a Nubank credit card invoice PDF.
+ * Only parses lines with the "DD MMM •••• NNNN" card marker — fees,
+ * payments and interest lines are intentionally skipped.
+ */
+export function extractNubankCreditCardInvoiceTransactions(
+  text: string,
+  confidence: number
+): StatementTransaction[] {
+  const referenceDate = extractNubankInvoiceDate(text) || new Date();
+  const transactions: StatementTransaction[] = [];
+
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  for (const line of lines) {
+    const tx = parseNubankInvoicePurchase(line, referenceDate, confidence);
+    if (tx) transactions.push(tx);
+  }
+
+  return transactions;
+}
+
 /**
  * Main function to parse statement text from OCR
  */
@@ -1067,6 +1191,16 @@ export function parseStatementText(
     if (cardTransactions.length > 0) {
       return buildParseResult(detectCardScreenshotBank(text), cardTransactions);
     }
+  }
+
+  // Detect Nubank credit card invoice PDF (must come before Nubank bank statement
+  // check, since invoices also contain "Nubank" + "DD MMM YYYY" headers)
+  if (isNubankCreditCardInvoice(text)) {
+    const invoiceTxs = extractNubankCreditCardInvoiceTransactions(
+      text,
+      ocrConfidence
+    );
+    return buildParseResult("Fatura Nubank", invoiceTxs);
   }
 
   // Detect if this is a C6 Bank statement

--- a/src/lib/statement-parser.ts
+++ b/src/lib/statement-parser.ts
@@ -343,11 +343,12 @@ function parseAmount(amountStr: string): number {
   // Remove R$ and spaces
   let cleaned = amountStr.replace(/R\$?\s*/g, "").trim();
 
-  // Check for negative indicator
-  const isNegative = cleaned.includes("-") || cleaned.endsWith("D");
+  // Check for negative indicator — U+002D HYPHEN-MINUS or U+2212 MINUS SIGN
+  // (Nubank PDFs use U+2212 for negative amounts; most other sources use U+002D)
+  const isNegative = /[−-]/.test(cleaned) || cleaned.endsWith("D");
 
   // Remove signs and D/C indicators
-  cleaned = cleaned.replace(/[-+CD]/g, "").trim();
+  cleaned = cleaned.replace(/[−\-+CD]/g, "").trim();
 
   // Remove thousand separators and convert decimal separator
   cleaned = cleaned.replace(/\./g, "").replace(",", ".");
@@ -1057,7 +1058,7 @@ const NUBANK_INVOICE_HEADER_PATTERN =
 // Purchase line: "04 MAR •••• 3746 Odp-Outlet D*Odptech - Parcela 2/2 R$ 31,78"
 // Captures: day, month, card4, description, amount (with optional minus sign)
 const NUBANK_INVOICE_PURCHASE_PATTERN =
-  /^(\d{1,2})\s+(JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+[•·\*]{3,}\s*(\d{4})\s+(.+?)\s+([−\-]?\s*R\$\s*[\d.,]+)\s*$/i;
+  /^(\d{1,2})\s+(JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+[•·\*]{2,}\s*(\d{4})\s+(.+?)\s+([−\-]?\s*R\$\s*[\d.,]+)\s*$/i;
 
 /**
  * Detect if this is a Nubank credit card invoice PDF.
@@ -1076,7 +1077,7 @@ function isNubankCreditCardInvoice(text: string): boolean {
     /TRANSA[CÇ][OÕ]ES\s+DE\s+\d{1,2}\s+\w+\s+A\s+\d{1,2}\s+\w+/i.test(text);
   const hasTotalAPagar = /Total\s+a\s+pagar/i.test(text);
   const hasPurchaseLines =
-    /\d{1,2}\s+(?:JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+[•·\*]{3,}\s*\d{4}/i.test(
+    /\d{1,2}\s+(?:JAN|FEV|MAR|ABR|MAI|JUN|JUL|AGO|SET|OUT|NOV|DEZ)\s+[•·\*]{2,}\s*\d{4}/i.test(
       text
     );
 
@@ -1130,13 +1131,12 @@ function parseNubankInvoicePurchase(
   const description = match[4].trim();
   if (description.length < 2) return null;
 
-  const amountStr = match[5];
-  const rawAmount = parseAmount(amountStr);
+  const rawAmount = parseAmount(match[5]);
   if (rawAmount === 0) return null;
 
-  // Minus sign (− U+2212 or - U+002D) before R$ indicates refund/estorno
-  const isNegative = /^\s*[−\-]/.test(amountStr);
-  const type: TransactionType = isNegative ? "INCOME" : "EXPENSE";
+  // parseAmount already applies the minus sign (U+2212 or U+002D) to the value.
+  // Negative purchase → refund/estorno (INCOME). Positive → regular purchase (EXPENSE).
+  const type: TransactionType = rawAmount < 0 ? "INCOME" : "EXPENSE";
 
   return {
     date,
@@ -1221,10 +1221,15 @@ function isItauNoiseLine(line: string): boolean {
 /**
  * Extract transactions from an Itaú credit card invoice screenshot.
  * Uses state tracking: date headers + pending description + amount lines.
+ *
+ * `referenceDate` is used to infer the year for "DD de MONTH" headers (which
+ * don't carry the year). Defaults to `new Date()` — pass an explicit value
+ * in tests to avoid time-dependent behavior.
  */
 export function extractItauInvoiceTransactions(
   text: string,
-  confidence: number
+  confidence: number,
+  referenceDate: Date = new Date()
 ): StatementTransaction[] {
   const lines = text
     .split("\n")
@@ -1235,9 +1240,8 @@ export function extractItauInvoiceTransactions(
   let currentDate: Date | null = null;
   let pendingDescription: string | null = null;
 
-  const now = new Date();
-  const refYear = now.getFullYear();
-  const refMonth = now.getMonth();
+  const refYear = referenceDate.getFullYear();
+  const refMonth = referenceDate.getMonth();
 
   const amountPattern = /R\$\s*(\d{1,3}(?:\.\d{3})*,\d{2})/;
 
@@ -1251,8 +1255,9 @@ export function extractItauInvoiceTransactions(
         // If month is in the future relative to today, it's from the previous year
         const year = month > refMonth ? refYear - 1 : refYear;
         currentDate = new Date(year, month, day);
+        pendingDescription = null;
       }
-      pendingDescription = null;
+      // Invalid date lookup → keep previous state, don't silently re-attribute
       continue;
     }
 
@@ -1262,9 +1267,7 @@ export function extractItauInvoiceTransactions(
     if (amountMatch) {
       if (!currentDate) continue;
 
-      const amount = parseFloat(
-        amountMatch[1].replace(/\./g, "").replace(",", ".")
-      );
+      const amount = parseAmount(amountMatch[0]);
       if (amount <= 0) continue;
 
       const amountStart = line.indexOf(amountMatch[0]);

--- a/src/lib/statement-parser.ts
+++ b/src/lib/statement-parser.ts
@@ -1172,6 +1172,136 @@ export function extractNubankCreditCardInvoiceTransactions(
   return transactions;
 }
 
+// ===== Itaú credit card invoice screenshot format =====
+
+// Date header: "ontem, 18 de abril" or "15 de abril" (lowercase month, optional "ontem,")
+const ITAU_INVOICE_DATE_PATTERN =
+  /^(?:ontem,?\s*)?(\d{1,2})\s+de\s+(janeiro|fevereiro|mar[cç]o|abril|maio|junho|julho|agosto|setembro|outubro|novembro|dezembro)\s*$/i;
+
+// Card type line (noise): "cartão físico", "cartão virtual em 2x"
+const ITAU_CARD_TYPE_PATTERN =
+  /^cart[aã]o\s+(?:f[ií]sico|virtual)(?:\s+em\s+\d+x)?\s*$/i;
+
+/**
+ * Detect Itaú credit card invoice screenshot: multiple "DD de MONTH" headers +
+ * "cartão físico/virtual" sub-labels + R$ amounts.
+ */
+function isItauInvoiceScreenshot(text: string): boolean {
+  const lines = text.split("\n").map((l) => l.trim());
+  const dateHeaders = lines.filter((l) => ITAU_INVOICE_DATE_PATTERN.test(l)).length;
+  const cardTypes = lines.filter((l) => ITAU_CARD_TYPE_PATTERN.test(l)).length;
+  const hasAmounts = /R\$\s*\d{1,3}(?:\.\d{3})*,\d{2}/.test(text);
+  return dateHeaders >= 1 && cardTypes >= 1 && hasAmounts;
+}
+
+/**
+ * Strip OCR noise from start of inline description.
+ * Tesseract often prepends icon glyphs as 1-3 char tokens (e.g., "BP", "CC)", "6 ").
+ * Only strip the leading token when the rest still has a real merchant word (≥4 alpha chars).
+ */
+function cleanItauInlineDescription(text: string): string {
+  const trimmed = text.replace(/^[^a-zA-Z0-9*]+/, "").trim();
+  const match = trimmed.match(/^(\S{1,3})\s+(.+)$/);
+  if (match && /[a-zA-Z]{4,}/.test(match[2])) {
+    return match[2].replace(/\s+/g, " ").trim();
+  }
+  return trimmed.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Detect lines that are pure noise (status bar, navigation icons).
+ */
+function isItauNoiseLine(line: string): boolean {
+  if (/^\d{1,2}:\d{2}/.test(line)) return true; // status bar time
+  if (line.length <= 6 && /^[<>←→]/.test(line)) return true; // back/nav arrows
+  if (/^[^a-zA-Z0-9]+$/.test(line)) return true; // symbols only
+  return false;
+}
+
+/**
+ * Extract transactions from an Itaú credit card invoice screenshot.
+ * Uses state tracking: date headers + pending description + amount lines.
+ */
+export function extractItauInvoiceTransactions(
+  text: string,
+  confidence: number
+): StatementTransaction[] {
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  const transactions: StatementTransaction[] = [];
+  let currentDate: Date | null = null;
+  let pendingDescription: string | null = null;
+
+  const now = new Date();
+  const refYear = now.getFullYear();
+  const refMonth = now.getMonth();
+
+  const amountPattern = /R\$\s*(\d{1,3}(?:\.\d{3})*,\d{2})/;
+
+  for (const line of lines) {
+    const dateMatch = line.match(ITAU_INVOICE_DATE_PATTERN);
+    if (dateMatch) {
+      const day = parseInt(dateMatch[1], 10);
+      const monthName = dateMatch[2].toLowerCase().replace("ç", "c");
+      const month = MONTH_FULL[monthName];
+      if (month !== undefined && day >= 1 && day <= 31) {
+        // If month is in the future relative to today, it's from the previous year
+        const year = month > refMonth ? refYear - 1 : refYear;
+        currentDate = new Date(year, month, day);
+      }
+      pendingDescription = null;
+      continue;
+    }
+
+    if (ITAU_CARD_TYPE_PATTERN.test(line)) continue;
+
+    const amountMatch = line.match(amountPattern);
+    if (amountMatch) {
+      if (!currentDate) continue;
+
+      const amount = parseFloat(
+        amountMatch[1].replace(/\./g, "").replace(",", ".")
+      );
+      if (amount <= 0) continue;
+
+      const amountStart = line.indexOf(amountMatch[0]);
+      const inlineDesc = cleanItauInlineDescription(line.substring(0, amountStart));
+
+      let description: string;
+      if (pendingDescription && pendingDescription.length >= 2) {
+        description = pendingDescription;
+      } else if (inlineDesc.length >= 3 && /[a-zA-Z]/.test(inlineDesc)) {
+        description = inlineDesc;
+      } else {
+        pendingDescription = null;
+        continue;
+      }
+
+      transactions.push({
+        date: new Date(currentDate),
+        description,
+        amount: -Math.abs(amount),
+        type: "EXPENSE",
+        confidence,
+      });
+
+      pendingDescription = null;
+      continue;
+    }
+
+    if (isItauNoiseLine(line)) continue;
+
+    if (line.length >= 2) {
+      pendingDescription = line;
+    }
+  }
+
+  return transactions;
+}
+
 /**
  * Main function to parse statement text from OCR
  */
@@ -1201,6 +1331,15 @@ export function parseStatementText(
       ocrConfidence
     );
     return buildParseResult("Fatura Nubank", invoiceTxs);
+  }
+
+  // Detect Itaú credit card invoice screenshot (uses "DD de MONTH" +
+  // "cartão físico/virtual" layout — different from "Fatura" header screenshots)
+  if (isItauInvoiceScreenshot(text)) {
+    const itauTxs = extractItauInvoiceTransactions(text, ocrConfidence);
+    if (itauTxs.length > 0) {
+      return buildParseResult("Fatura Itaú", itauTxs);
+    }
   }
 
   // Detect if this is a C6 Bank statement


### PR DESCRIPTION
## Contexto

Dois bugs impediam a importação de faturas de cartão de crédito pela tela de OCR — ambos retornavam `"Nenhuma transação encontrada no arquivo"`.

### 1. Fatura Nubank em PDF (commit `bb86eea`)

`isNubankStatement()` casava tanto com extratos bancários quanto com faturas de cartão (bastava "Nubank" + data `DD MMM YYYY` no cabeçalho). O PDF era roteado ao parser de extrato, que só reconhece linhas tipo `Transferência recebida…` / `Compra no débito…`. Faturas usam formato completamente diferente: `DD MMM •••• NNNN Descrição R$ XX,XX`.

**Fix:** `isNubankCreditCardInvoice()` + `extractNubankCreditCardInvoiceTransactions()` com detecção por ≥2 sinais (header `FATURA`, seção `TRANSAÇÕES DE`, `Total a pagar`, linhas `•••• NNNN`). Usa a data do `FATURA` como referência para inferir ano. Linhas de pagamentos/juros/multas em "Pagamentos e Financiamentos" são intencionalmente ignoradas (duplicariam lançamentos do extrato bancário).

### 2. Fatura Itaú em screenshot (commit `ece6b29`)

Screenshot da fatura em aberto do app do Itaú (não exportável como PDF). Layout diferente de C6/Nubank: sem header `Fatura`, datas em PT-BR lowercase (`"ontem, 18 de abril"`, `"15 de abril"`) como separadores entre blocos, ícones de categoria aparecendo como lixo no OCR (`"BP "`, `"CC) "`, `"6 "` antes do merchant).

**Fix:** `isItauInvoiceScreenshot()` + `extractItauInvoiceTransactions()` com máquina de estados (data atual + descrição pendente). Heurística preferindo a linha de descrição limpa quando disponível (ex.: `"99*"` é mais confiável que o `"CC) ao"` garbled no OCR da linha do valor), com fallback para strip de token curto na descrição inline.

Observação: o "travado em 90%" relatado pelo usuário é artefato de UI (`Math.min(prev + 5, 90)` no `import/page.tsx`) enquanto o Tesseract roda — não era bug.

### 3. Fixtures mockadas (commit `0a808d6`)

Fixtures originais continham nome real do titular e merchants reais. Substituídos por dados fictícios (`"Loja A/B/C"`, `"loja alpha/beta"`, valores arbitrários) preservando todo o layout/sintaxe que o parser precisa. Alinhamento com política de não commitar dados pessoais em testes.

## Test plan

- [x] `npm run test:unit -- statement-parser` — 45/45 passam
- [x] Reprodução manual com PDF real do Nubank → 11 transações extraídas, total bate com subtotal da fatura
- [x] Reprodução manual com screenshot real do Itaú → 7 transações extraídas, total bate
- [ ] Revisar no app pelo fluxo de Importar Transações