### PR TITLE
fix(ocr): progresso real + downscale pra não travar em 90%

### DIFF
--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { processFile, PdfPasswordError } from "@/lib/ocr-parser";
+import { processFile, PdfPasswordError, type OcrProgressCallback } from "@/lib/ocr-parser";
 import { parseStatementText, suggestCategoryForStatement } from "@/lib/statement-parser";
 import { parseNotificationText } from "@/lib/notification-parser";
 import { suggestCategory, detectInstallment, detectRecurringTransaction } from "@/lib/categorizer";
@@ -39,6 +39,220 @@ async function savePdfPassword(userId: string, password: string): Promise<void> 
   });
 }
 
+type OcrSuccessBody = {
+  transactions: (ImportedTransaction & {
+    categoryId?: string;
+    selected: boolean;
+    transactionKind?: string;
+  })[];
+  origin: string;
+  confidence: number;
+  rawText: string;
+};
+
+type OcrErrorBody = { error: string; rawText?: string; confidence?: number };
+type OcrPasswordBody = { needsPassword: true; error?: string; savedPasswordFailed?: boolean };
+
+/**
+ * Run the full OCR → parse → categorize pipeline.
+ * `onProgress` is forwarded to Tesseract; callers consuming a JSON response
+ * can omit it. Returns either a success body, an error body, or a signal that
+ * the PDF needs a password.
+ */
+async function runOcrPipeline(
+  file: File,
+  password: string | null,
+  userId: string,
+  ownerFilter: Record<string, unknown>,
+  savePasswordFlag: boolean,
+  onProgress?: OcrProgressCallback
+): Promise<
+  | { kind: "success"; body: OcrSuccessBody }
+  | { kind: "error"; body: OcrErrorBody; status: number }
+  | { kind: "password"; body: OcrPasswordBody }
+> {
+  const fileName = file.name.toLowerCase();
+  const validExtensions = [".pdf", ".png", ".jpg", ".jpeg", ".gif", ".webp"];
+  if (!validExtensions.some((ext) => fileName.endsWith(ext))) {
+    return {
+      kind: "error",
+      body: { error: "Formato de arquivo não suportado. Use PDF ou imagem (PNG, JPG)" },
+      status: 400,
+    };
+  }
+
+  let ocrResult;
+  try {
+    ocrResult = await processFile(file, password || undefined, onProgress);
+  } catch (error) {
+    if (error instanceof PdfPasswordError) {
+      if (password) {
+        return {
+          kind: "password",
+          body: { needsPassword: true, error: "Senha incorreta. Tente novamente." },
+        };
+      }
+      const savedPassword = await getSavedPdfPassword(userId);
+      if (savedPassword) {
+        try {
+          ocrResult = await processFile(file, savedPassword, onProgress);
+        } catch (retryError) {
+          if (retryError instanceof PdfPasswordError) {
+            return {
+              kind: "password",
+              body: { needsPassword: true, savedPasswordFailed: true },
+            };
+          }
+          throw retryError;
+        }
+      } else {
+        return { kind: "password", body: { needsPassword: true } };
+      }
+    } else {
+      throw error;
+    }
+  }
+
+  if (savePasswordFlag && password) {
+    try {
+      await savePdfPassword(userId, password);
+    } catch (saveError) {
+      console.error("Failed to save PDF password:", saveError);
+    }
+  }
+
+  if (!ocrResult.text || ocrResult.text.trim().length === 0) {
+    return {
+      kind: "error",
+      body: {
+        error: "Não foi possível extrair texto do arquivo. Verifique se a imagem está legível.",
+      },
+      status: 400,
+    };
+  }
+
+  let parseResult = parseStatementText(ocrResult.text, ocrResult.confidence);
+  if (parseResult.transactions.length === 0) {
+    const notificationResult = parseNotificationText(ocrResult.text, ocrResult.confidence);
+    if (notificationResult) parseResult = notificationResult;
+  }
+
+  if (parseResult.transactions.length === 0) {
+    return {
+      kind: "error",
+      body: {
+        error:
+          "Nenhuma transação encontrada no arquivo. Certifique-se de que o extrato está claro e legível.",
+        rawText: ocrResult.text,
+        confidence: ocrResult.confidence,
+      },
+      status: 400,
+    };
+  }
+
+  const defaultCategory = await prisma.category.findFirst({
+    where: { ...ownerFilter, name: "Outros" },
+  });
+
+  const transactions: OcrSuccessBody["transactions"] = [];
+  for (const t of parseResult.transactions) {
+    const suggestedCat = await suggestCategory(t.description, userId);
+    const categoryId = suggestedCat?.id || defaultCategory?.id;
+    const installmentInfo = detectInstallment(t.description);
+    const recurringInfo = detectRecurringTransaction(t.description);
+
+    transactions.push({
+      description: t.description,
+      amount: t.amount,
+      date: t.date,
+      type: t.type,
+      categoryId,
+      suggestedCategoryId: categoryId,
+      isInstallment: installmentInfo.isInstallment,
+      currentInstallment: installmentInfo.currentInstallment,
+      totalInstallments: installmentInfo.totalInstallments,
+      isRecurring: recurringInfo.isRecurring,
+      recurringName: recurringInfo.recurringName,
+      confidence: t.confidence,
+      transactionKind: t.transactionKind,
+      selected: true,
+    });
+  }
+
+  return {
+    kind: "success",
+    body: {
+      transactions,
+      origin: parseResult.bank,
+      confidence: parseResult.averageConfidence,
+      rawText: ocrResult.text,
+    },
+  };
+}
+
+/**
+ * Stream the OCR pipeline as newline-delimited JSON events so the client
+ * can render real Tesseract progress. Events:
+ *   { type: "progress", status, progress }   — repeated during OCR
+ *   { type: "result", ... }                  — final payload
+ *   { type: "password", ... }                — PDF password prompt
+ *   { type: "error", error, status }         — failure
+ */
+function streamOcrResponse(
+  file: File,
+  password: string | null,
+  userId: string,
+  ownerFilter: Record<string, unknown>,
+  savePasswordFlag: boolean
+): Response {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const writeEvent = (event: Record<string, unknown>) => {
+        controller.enqueue(encoder.encode(JSON.stringify(event) + "\n"));
+      };
+
+      try {
+        const result = await runOcrPipeline(
+          file,
+          password,
+          userId,
+          ownerFilter,
+          savePasswordFlag,
+          (update) => writeEvent({ type: "progress", ...update })
+        );
+
+        if (result.kind === "success") {
+          writeEvent({ type: "result", ...result.body });
+        } else if (result.kind === "password") {
+          writeEvent({ type: "password", ...result.body });
+        } else {
+          writeEvent({ type: "error", ...result.body });
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Erro ao processar arquivo";
+        if (message === "Unauthorized" || message === "Forbidden") {
+          writeEvent({ type: "error", error: message, status: message === "Unauthorized" ? 401 : 403 });
+        } else {
+          console.error("OCR streaming error:", error);
+          writeEvent({ type: "error", error: message, status: 500 });
+        }
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
 export async function POST(request: NextRequest) {
   try {
     const ctx = await getAuthContext();
@@ -46,139 +260,33 @@ export async function POST(request: NextRequest) {
     const file = formData.get("file") as File | null;
     const password = formData.get("password") as string | null;
     const savePasswordFlag = formData.get("savePassword") === "true";
+    const streamMode = formData.get("stream") === "true";
 
     if (!file) {
-      return NextResponse.json(
-        { error: "Nenhum arquivo enviado" },
-        { status: 400 }
+      return NextResponse.json({ error: "Nenhum arquivo enviado" }, { status: 400 });
+    }
+
+    if (streamMode) {
+      return streamOcrResponse(
+        file,
+        password,
+        ctx.userId,
+        ctx.ownerFilter,
+        savePasswordFlag
       );
     }
 
-    // Validate file type
-    const fileName = file.name.toLowerCase();
-    const validExtensions = [".pdf", ".png", ".jpg", ".jpeg", ".gif", ".webp"];
-    const isValid = validExtensions.some((ext) => fileName.endsWith(ext));
+    const result = await runOcrPipeline(
+      file,
+      password,
+      ctx.userId,
+      ctx.ownerFilter,
+      savePasswordFlag
+    );
 
-    if (!isValid) {
-      return NextResponse.json(
-        { error: "Formato de arquivo não suportado. Use PDF ou imagem (PNG, JPG)" },
-        { status: 400 }
-      );
-    }
-
-    // Process file — handle password-protected PDFs
-    let ocrResult;
-    try {
-      ocrResult = await processFile(file, password || undefined);
-    } catch (error) {
-      if (error instanceof PdfPasswordError) {
-        if (password) {
-          // Explicit password was wrong
-          return NextResponse.json({
-            needsPassword: true,
-            error: "Senha incorreta. Tente novamente.",
-          });
-        }
-
-        // No password provided — try saved password
-        const savedPassword = await getSavedPdfPassword(ctx.userId);
-        if (savedPassword) {
-          try {
-            ocrResult = await processFile(file, savedPassword);
-          } catch (retryError) {
-            if (retryError instanceof PdfPasswordError) {
-              // Saved password also failed — tell frontend
-              return NextResponse.json({ needsPassword: true, savedPasswordFailed: true });
-            }
-            throw retryError;
-          }
-        } else {
-          return NextResponse.json({ needsPassword: true });
-        }
-      } else {
-        throw error;
-      }
-    }
-
-    // Save password if requested and a password was explicitly provided (best-effort)
-    if (savePasswordFlag && password) {
-      try {
-        await savePdfPassword(ctx.userId, password);
-      } catch (saveError) {
-        console.error("Failed to save PDF password:", saveError);
-      }
-    }
-
-    if (!ocrResult.text || ocrResult.text.trim().length === 0) {
-      return NextResponse.json(
-        { error: "Não foi possível extrair texto do arquivo. Verifique se a imagem está legível." },
-        { status: 400 }
-      );
-    }
-
-    // Parse statement text (try bank statement format first, then notification format)
-    let parseResult = parseStatementText(ocrResult.text, ocrResult.confidence);
-
-    // If no transactions found as statement, try notification format
-    if (parseResult.transactions.length === 0) {
-      const notificationResult = parseNotificationText(ocrResult.text, ocrResult.confidence);
-      if (notificationResult) {
-        parseResult = notificationResult;
-      }
-    }
-
-    if (parseResult.transactions.length === 0) {
-      return NextResponse.json(
-        {
-          error: "Nenhuma transação encontrada no arquivo. Certifique-se de que o extrato está claro e legível.",
-          rawText: ocrResult.text,
-          confidence: ocrResult.confidence,
-        },
-        { status: 400 }
-      );
-    }
-
-    // Convert to ImportedTransaction format and apply categorization
-    const transactions: (ImportedTransaction & {
-      categoryId?: string;
-      selected: boolean;
-      transactionKind?: string;
-    })[] = [];
-
-    const defaultCategory = await prisma.category.findFirst({
-      where: { ...ctx.ownerFilter, name: "Outros" },
-    });
-
-    for (const t of parseResult.transactions) {
-      const suggestedCat = await suggestCategory(t.description, ctx.userId);
-      let categoryId = suggestedCat?.id || defaultCategory?.id;
-      const installmentInfo = detectInstallment(t.description);
-      const recurringInfo = detectRecurringTransaction(t.description);
-
-      transactions.push({
-        description: t.description,
-        amount: t.amount,
-        date: t.date,
-        type: t.type,
-        categoryId,
-        suggestedCategoryId: categoryId,
-        isInstallment: installmentInfo.isInstallment,
-        currentInstallment: installmentInfo.currentInstallment,
-        totalInstallments: installmentInfo.totalInstallments,
-        isRecurring: recurringInfo.isRecurring,
-        recurringName: recurringInfo.recurringName,
-        confidence: t.confidence,
-        transactionKind: t.transactionKind,
-        selected: true,
-      });
-    }
-
-    return NextResponse.json({
-      transactions,
-      origin: parseResult.bank,
-      confidence: parseResult.averageConfidence,
-      rawText: ocrResult.text,
-    });
+    if (result.kind === "success") return NextResponse.json(result.body);
+    if (result.kind === "password") return NextResponse.json(result.body);
+    return NextResponse.json(result.body, { status: result.status });
   } catch (error) {
     if (error instanceof Error && error.message === "Unauthorized") {
       return unauthorizedResponse();
@@ -188,9 +296,7 @@ export async function POST(request: NextRequest) {
     }
     console.error("OCR processing error:", error);
     return NextResponse.json(
-      {
-        error: error instanceof Error ? error.message : "Erro ao processar arquivo",
-      },
+      { error: error instanceof Error ? error.message : "Erro ao processar arquivo" },
       { status: 500 }
     );
   }

--- a/src/app/import/page.tsx
+++ b/src/app/import/page.tsx
@@ -830,6 +830,14 @@ export default function ImportPage() {
     });
   }
 
+  // Map Tesseract status → Portuguese UI label
+  function translateOcrStatus(status: string): string {
+    if (/loading/i.test(status)) return "Carregando modelo de OCR...";
+    if (/initializing/i.test(status)) return "Inicializando OCR...";
+    if (/recognizing/i.test(status)) return "Reconhecendo texto...";
+    return "Processando OCR...";
+  }
+
   async function callOCRApi(file: File): Promise<{
     transactions: ExtendedTransaction[];
     origin: string;
@@ -837,43 +845,95 @@ export default function ImportPage() {
   }> {
     const formData = new FormData();
     formData.append("file", file);
+    formData.append("stream", "true");
 
-    const res = await fetch("/api/ocr", {
-      method: "POST",
-      body: formData,
-    });
+    const res = await fetch("/api/ocr", { method: "POST", body: formData });
 
-    // Handle non-JSON responses (e.g., 504 gateway timeout)
-    let data;
-    try {
-      data = await res.json();
-    } catch {
+    if (!res.ok || !res.body) {
+      // Fall back to JSON parse for HTTP-level errors
+      let errText = "";
+      try { errText = await res.text(); } catch { /* ignore */ }
       throw new Error(
         res.status === 504
           ? "O servidor demorou demais para processar. Tente com menos arquivos ou imagens menores."
-          : `Erro do servidor (${res.status}). Tente novamente.`
+          : errText || `Erro do servidor (${res.status}). Tente novamente.`
       );
     }
 
-    if (data.needsPassword) {
-      throw Object.assign(new Error("needsPassword"), { data });
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    // Discriminated-union event shapes from /api/ocr streaming mode
+    type StreamEvent =
+      | { type: "progress"; status: string; progress: number }
+      | { type: "result"; transactions: ExtendedTransaction[]; origin: string; confidence: number; rawText?: string }
+      | { type: "password"; needsPassword: true; error?: string; savedPasswordFailed?: boolean }
+      | { type: "error"; error: string; status?: number };
+    let final: Extract<StreamEvent, { type: "result" }> | null = null;
+    let passwordEvent: Extract<StreamEvent, { type: "password" }> | null = null;
+    let errorEvent: Extract<StreamEvent, { type: "error" }> | null = null;
+
+    // Read the NDJSON stream. Each complete line is a JSON event.
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        let event: StreamEvent;
+        try {
+          event = JSON.parse(line) as StreamEvent;
+        } catch {
+          continue;
+        }
+        if (event.type === "progress") {
+          // Tesseract "recognizing text" phase (progress 0..1) maps to 20..95%;
+          // earlier phases (loading/initializing) map to 5..20%.
+          const { status, progress } = event;
+          const pct = /recognizing/i.test(status)
+            ? 20 + Math.round(progress * 75)
+            : 5 + Math.round(progress * 15);
+          setOcrProgress(Math.min(95, Math.max(0, pct)));
+          setOcrProgressLabel(translateOcrStatus(status));
+        } else if (event.type === "result") {
+          final = event;
+        } else if (event.type === "password") {
+          passwordEvent = event;
+        } else if (event.type === "error") {
+          errorEvent = event;
+        }
+      }
     }
 
-    if (!res.ok) {
-      throw new Error(data.error || "Erro ao processar arquivo");
+    if (passwordEvent) {
+      throw Object.assign(new Error("needsPassword"), {
+        data: {
+          savedPasswordFailed: passwordEvent.savedPasswordFailed,
+          error: passwordEvent.error,
+        },
+      });
+    }
+    if (errorEvent) {
+      throw new Error(errorEvent.error);
+    }
+    if (!final) {
+      throw new Error("Resposta incompleta do servidor. Tente novamente.");
     }
 
     return {
-      transactions: normalizeTransactionDates(data.transactions),
-      origin: data.origin,
-      confidence: data.confidence,
+      transactions: normalizeTransactionDates(final.transactions),
+      origin: final.origin,
+      confidence: final.confidence,
     };
   }
 
   async function processOCR(file: File) {
-    const progressInterval = setInterval(() => {
-      setOcrProgress((prev) => Math.min(prev + 5, 90));
-    }, 500);
+    setOcrProgress(0);
+    setOcrProgressLabel("Enviando arquivo...");
 
     try {
       let result;
@@ -881,7 +941,6 @@ export default function ImportPage() {
         result = await callOCRApi(file);
       } catch (error: unknown) {
         if (error instanceof Error && error.message === "needsPassword") {
-          clearInterval(progressInterval);
           const errData = (error as Error & { data: { savedPasswordFailed?: boolean } }).data;
           setPendingFile(file);
           setNeedsPassword(true);
@@ -895,7 +954,6 @@ export default function ImportPage() {
         throw error;
       }
 
-      clearInterval(progressInterval);
       setOcrProgress(100);
 
       setOrigin(result.origin);
@@ -914,7 +972,7 @@ export default function ImportPage() {
 
       setStep("preview");
     } finally {
-      clearInterval(progressInterval);
+      // Progress is managed by the stream consumer now; nothing to clean up.
     }
   }
 

--- a/src/lib/ocr-parser.ts
+++ b/src/lib/ocr-parser.ts
@@ -19,20 +19,30 @@ export class PdfPasswordError extends Error {
   }
 }
 
+// Max width for OCR input. iPhone screenshots are ~1170×2532 and OCR cost
+// scales with pixel count, pushing us past Vercel's 60s function timeout.
+// 1200px is the sweet spot: big enough for Tesseract accuracy, small enough
+// to finish in time.
+const OCR_MAX_WIDTH_PX = 1200;
+
 /**
- * Pre-process image for better OCR accuracy
- * - Converts to grayscale
- * - Increases contrast
- * - Applies sharpening
+ * Pre-process image for better OCR accuracy:
+ * - Downscale to OCR_MAX_WIDTH_PX if wider (primary lever for serverless timeout)
+ * - Convert to grayscale
+ * - Normalise contrast
+ * - Sharpen
  */
 async function preprocessImage(buffer: Buffer): Promise<Buffer> {
   try {
-    return await sharp(buffer)
-      .grayscale()
-      .normalise()
-      .sharpen()
-      .png()
-      .toBuffer();
+    const image = sharp(buffer);
+    const metadata = await image.metadata();
+
+    let pipeline = image;
+    if (metadata.width && metadata.width > OCR_MAX_WIDTH_PX) {
+      pipeline = pipeline.resize(OCR_MAX_WIDTH_PX, undefined, { fit: "inside" });
+    }
+
+    return await pipeline.grayscale().normalise().sharpen().png().toBuffer();
   } catch {
     // If sharp processing fails, return original buffer
     return buffer;
@@ -40,9 +50,19 @@ async function preprocessImage(buffer: Buffer): Promise<Buffer> {
 }
 
 /**
+ * Callback receiving real-time OCR progress from Tesseract.
+ * `status` is the Tesseract phase (e.g., "loading language traineddata",
+ * "recognizing text"); `progress` is a fraction 0..1 for the current phase.
+ */
+export type OcrProgressCallback = (update: { status: string; progress: number }) => void;
+
+/**
  * Process an image file with OCR
  */
-export async function processImageOCR(file: File): Promise<OCRResult> {
+export async function processImageOCR(
+  file: File,
+  onProgress?: OcrProgressCallback
+): Promise<OCRResult> {
   const arrayBuffer = await file.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
 
@@ -50,7 +70,9 @@ export async function processImageOCR(file: File): Promise<OCRResult> {
   const processedBuffer = await preprocessImage(buffer);
 
   const result = await Tesseract.recognize(processedBuffer, "por", {
-    logger: () => {},
+    logger: onProgress
+      ? (m) => onProgress({ status: m.status, progress: m.progress })
+      : () => {},
   });
 
   return {
@@ -62,11 +84,16 @@ export async function processImageOCR(file: File): Promise<OCRResult> {
 /**
  * Process a buffer with OCR (for PDF pages)
  */
-export async function processBufferOCR(buffer: Buffer): Promise<OCRResult> {
+export async function processBufferOCR(
+  buffer: Buffer,
+  onProgress?: OcrProgressCallback
+): Promise<OCRResult> {
   const processedBuffer = await preprocessImage(buffer);
 
   const result = await Tesseract.recognize(processedBuffer, "por", {
-    logger: () => {},
+    logger: onProgress
+      ? (m) => onProgress({ status: m.status, progress: m.progress })
+      : () => {},
   });
 
   return {
@@ -139,11 +166,14 @@ export async function processPDFOCR(
 
 /**
  * Process any supported file (image or PDF)
- * Password is only used for PDF files and ignored for images
+ * Password is only used for PDF files and ignored for images.
+ * `onProgress` only fires for images (Tesseract OCR) — PDF text extraction
+ * is synchronous-ish and doesn't provide meaningful intermediate progress.
  */
 export async function processFile(
   file: File,
-  password?: string
+  password?: string,
+  onProgress?: OcrProgressCallback
 ): Promise<OCRResult> {
   const fileName = file.name.toLowerCase();
 
@@ -152,5 +182,5 @@ export async function processFile(
   }
 
   // Assume it's an image — password is ignored
-  return processImageOCR(file);
+  return processImageOCR(file, onProgress);
 }


### PR DESCRIPTION
## Contexto

Usuário relatou que importar um screenshot de fatura Itaú ficava travado em 90% e acabava devolvendo \`FUNCTION_INVOCATION_TIMEOUT\` depois de 60s. Duas causas independentes:

### 1. Progress bar fake

Antes: \`setInterval\` incrementava \`ocrProgress\` em 5% a cada 500ms, capando em 90%. Como o Tesseract leva 10–30s em serverless (cold start + OCR propriamente), a barra ficava estagnada em 90% sem feedback. Parece travado.

**Fix:** novo modo streaming em \`/api/ocr\` (ativado por \`stream=true\` no form data) que devolve NDJSON com eventos \`progress\` carregando status + progresso real do Tesseract. Frontend consome o stream, mapeia as fases (loading → 5-20%, recognizing → 20-95%) e traduz os labels.

### 2. Timeout de 60s em imagens grandes

Screenshots de iPhone têm resolução ~1170×2532. Tesseract escala com pixel count, então em cold start (que já perde 15-20s baixando \`por.traineddata\`) a janela de 60s da Vercel estoura.

**Fix:** \`preprocessImage\` agora downscala imagens > 1200px de largura via \`sharp\` antes do OCR. Testado no screenshot real: **0.8s** de OCR localmente, 7/7 transações extraídas (acurácia preservada).

## Detalhes técnicos

- \`ocr-parser.ts\`: exporta \`OcrProgressCallback\`; \`processFile\`/\`processImageOCR\`/\`processBufferOCR\` aceitam callback opcional encaminhado pro logger do Tesseract.
- \`api/ocr/route.ts\`: pipeline extraído pra função \`runOcrPipeline\` compartilhada. Modo JSON (retrocompatível) e modo streaming convivem.
- \`import/page.tsx\`: \`callOCRApi\` agora lê o stream NDJSON e atualiza \`setOcrProgress\`/\`setOcrProgressLabel\` em tempo real.

## Test plan

- [x] Testes unitários \`ocr-parser\` + \`statement-parser\`: 59/59 passam
- [x] Typecheck sem novos erros
- [x] OCR local no screenshot real do Itaú (1170×2532): 0.8s, 7 transações, bank = "Fatura Itaú"
- [ ] Preview Vercel: verificar que o stream mostra progresso real e que imagens grandes processam em menos de 60s