### PR TITLE
feat(telegram): unifica múltiplas imagens em 1 chamada Gemini (1 cota)

### DIFF
--- a/prisma/migrations/20260421000000_add_message_id_to_photo_queue/migration.sql
+++ b/prisma/migrations/20260421000000_add_message_id_to_photo_queue/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "TelegramPhotoQueue" ADD COLUMN "messageId" INTEGER;
+
+-- CreateIndex
+-- Composto com mediaGroupId porque o orderBy por messageId sempre roda dentro
+-- de um WHERE mediaGroupId = X (batch específico). Garante ordem estável das
+-- páginas no caminho multi-part do parser de IA.
+CREATE INDEX "TelegramPhotoQueue_mediaGroupId_messageId_idx" ON "TelegramPhotoQueue"("mediaGroupId", "messageId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -633,6 +633,11 @@ model TelegramPhotoQueue {
   userId        String
   mediaGroupId  String
   fileId        String
+  /// message_id do Telegram (int monotônico por chat). Fonte autoritativa
+  /// da ORDEM das páginas dentro do álbum — createdAt do DB pode empatar
+  /// quando N webhooks chegam quase simultaneamente. Opcional pra retrocompat
+  /// com entries criadas antes desta coluna existir.
+  messageId     Int?
   claimed       Boolean  @default(false)
   createdAt     DateTime @default(now())
 
@@ -640,6 +645,7 @@ model TelegramPhotoQueue {
 
   @@unique([mediaGroupId, fileId])
   @@index([mediaGroupId])
+  @@index([mediaGroupId, messageId])
   @@index([userId])
 }
 

--- a/src/lib/ai-parser/gemini-client.test.ts
+++ b/src/lib/ai-parser/gemini-client.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock do SDK oficial ANTES do import do módulo testado. O gemini-client
+// instancia um GoogleGenAI com a chave — substituímos o construtor por um
+// espião que captura os argumentos de generateContent.
+const generateContentMock = vi.fn();
+
+vi.mock("@google/genai", () => {
+  class GoogleGenAI {
+    models = { generateContent: generateContentMock };
+    constructor(_: unknown) {}
+  }
+  // Reexporta Type e qualquer outra coisa que schema.ts use em runtime.
+  const Type = {
+    STRING: "STRING",
+    NUMBER: "NUMBER",
+    OBJECT: "OBJECT",
+    ARRAY: "ARRAY",
+  };
+  return { GoogleGenAI, Type };
+});
+
+import { createGeminiClient } from "./gemini-client";
+
+describe("GeminiClient (RealGeminiClient): multi-part", () => {
+  beforeEach(() => {
+    generateContentMock.mockReset();
+    // Chave fake pra createGeminiClient() não retornar null.
+    process.env.GEMINI_API_KEY = "test-key";
+  });
+
+  function stubValidResponse() {
+    generateContentMock.mockResolvedValue({
+      text: JSON.stringify({
+        bank: "Nubank",
+        documentType: "fatura_cartao",
+        documentConfidence: 0.9,
+        transactions: [
+          { description: "PAG*IFOOD", amount: 45, date: "2026-03-15", type: "EXPENSE" },
+        ],
+      }),
+    });
+  }
+
+  it("single-file (buffer, mimeType): envia 1 inlineData part (backward compat)", async () => {
+    stubValidResponse();
+    const client = createGeminiClient();
+    expect(client).not.toBeNull();
+
+    await client!.generateInvoiceStructured(Buffer.from("xxx"), "application/pdf");
+
+    expect(generateContentMock).toHaveBeenCalledTimes(1);
+    const call = generateContentMock.mock.calls[0][0];
+    expect(call.contents[0].parts).toHaveLength(1);
+    expect(call.contents[0].parts[0].inlineData).toMatchObject({
+      mimeType: "application/pdf",
+    });
+    expect(call.contents[0].parts[0].inlineData.data).toBe(
+      Buffer.from("xxx").toString("base64")
+    );
+  });
+
+  it("multi-part (array): envia N inlineData parts na MESMA request (consume 1 cota)", async () => {
+    stubValidResponse();
+    const client = createGeminiClient();
+    expect(client).not.toBeNull();
+
+    const parts = [
+      { buffer: Buffer.from("img-1"), mimeType: "image/jpeg" },
+      { buffer: Buffer.from("img-2"), mimeType: "image/jpeg" },
+      { buffer: Buffer.from("img-3"), mimeType: "image/png" },
+    ];
+
+    await client!.generateInvoiceStructured(parts);
+
+    // CHAVE: 1 chamada ao Gemini pro batch inteiro
+    expect(generateContentMock).toHaveBeenCalledTimes(1);
+    const call = generateContentMock.mock.calls[0][0];
+    expect(call.contents[0].parts).toHaveLength(3);
+    expect(call.contents[0].parts[0].inlineData.mimeType).toBe("image/jpeg");
+    expect(call.contents[0].parts[0].inlineData.data).toBe(
+      Buffer.from("img-1").toString("base64")
+    );
+    expect(call.contents[0].parts[1].inlineData.mimeType).toBe("image/jpeg");
+    expect(call.contents[0].parts[1].inlineData.data).toBe(
+      Buffer.from("img-2").toString("base64")
+    );
+    expect(call.contents[0].parts[2].inlineData.mimeType).toBe("image/png");
+    expect(call.contents[0].parts[2].inlineData.data).toBe(
+      Buffer.from("img-3").toString("base64")
+    );
+  });
+
+  it("multi-part mistura mimetypes (PDF + imagem): permite extensão natural", async () => {
+    stubValidResponse();
+    const client = createGeminiClient();
+    expect(client).not.toBeNull();
+
+    const parts = [
+      { buffer: Buffer.from("pdf-content"), mimeType: "application/pdf" },
+      { buffer: Buffer.from("jpg-content"), mimeType: "image/jpeg" },
+    ];
+
+    await client!.generateInvoiceStructured(parts);
+
+    const call = generateContentMock.mock.calls[0][0];
+    expect(call.contents[0].parts).toHaveLength(2);
+    expect(call.contents[0].parts[0].inlineData.mimeType).toBe("application/pdf");
+    expect(call.contents[0].parts[1].inlineData.mimeType).toBe("image/jpeg");
+  });
+
+  it("array vazio: lança erro (contrato explícito)", async () => {
+    stubValidResponse();
+    const client = createGeminiClient();
+    expect(client).not.toBeNull();
+
+    await expect(client!.generateInvoiceStructured([])).rejects.toThrow(
+      /parts array não pode estar vazio/
+    );
+    expect(generateContentMock).not.toHaveBeenCalled();
+  });
+
+  it("createGeminiClient retorna null sem GEMINI_API_KEY", () => {
+    delete process.env.GEMINI_API_KEY;
+    expect(createGeminiClient()).toBeNull();
+  });
+});

--- a/src/lib/ai-parser/gemini-client.ts
+++ b/src/lib/ai-parser/gemini-client.ts
@@ -5,11 +5,48 @@ import { SYSTEM_PROMPT } from "./prompt";
 const MODEL = "gemini-2.5-flash-lite";
 const TIMEOUT_MS = 30_000; // budget apertado — endpoint tem 60s e fallback roda depois
 
+/**
+ * Part única anexada ao prompt. Suporta PDF ou imagem (qualquer mimetype
+ * aceito pelo Gemini inline). Múltiplas parts no mesmo prompt são enviadas
+ * como UM ÚNICO documento lógico — ver SYSTEM_PROMPT para a semântica.
+ */
+export interface GeminiInvoicePart {
+  buffer: Buffer;
+  mimeType: string;
+}
+
 export interface GeminiClient {
+  /**
+   * Chama o Gemini com 1..N parts em uma única request, consumindo UMA quota.
+   *
+   * Retrocompat: aceita também a forma single-file `(buffer, mimeType)`.
+   * A versão array é usada quando o usuário envia múltiplas imagens de um
+   * mesmo documento (ex: 3 prints de fatura de cartão) — o modelo trata
+   * todas como páginas/imagens contínuas do MESMO documento.
+   */
   generateInvoiceStructured(
     buffer: Buffer,
     mimeType: string
   ): Promise<AiInvoiceOutput>;
+  generateInvoiceStructured(
+    parts: GeminiInvoicePart[]
+  ): Promise<AiInvoiceOutput>;
+}
+
+function normalizeParts(
+  bufferOrParts: Buffer | GeminiInvoicePart[],
+  mimeType?: string
+): GeminiInvoicePart[] {
+  if (Array.isArray(bufferOrParts)) {
+    if (bufferOrParts.length === 0) {
+      throw new Error("generateInvoiceStructured: parts array não pode estar vazio");
+    }
+    return bufferOrParts;
+  }
+  if (typeof mimeType !== "string") {
+    throw new Error("generateInvoiceStructured: mimeType obrigatório quando buffer é single");
+  }
+  return [{ buffer: bufferOrParts, mimeType }];
 }
 
 class RealGeminiClient implements GeminiClient {
@@ -19,32 +56,43 @@ class RealGeminiClient implements GeminiClient {
     this.ai = new GoogleGenAI({ apiKey });
   }
 
-  async generateInvoiceStructured(
+  generateInvoiceStructured(
     buffer: Buffer,
     mimeType: string
+  ): Promise<AiInvoiceOutput>;
+  generateInvoiceStructured(
+    parts: GeminiInvoicePart[]
+  ): Promise<AiInvoiceOutput>;
+  async generateInvoiceStructured(
+    bufferOrParts: Buffer | GeminiInvoicePart[],
+    mimeType?: string
   ): Promise<AiInvoiceOutput> {
+    const parts = normalizeParts(bufferOrParts, mimeType);
     const controller = new AbortController();
     const timeoutHandle = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
     try {
       const response = await this.ai.models.generateContent({
         model: MODEL,
-        // `contents` carrega APENAS o input do usuário (o arquivo).
+        // `contents` carrega APENAS o input do usuário (o(s) arquivo(s)).
         // As instruções do sistema vão em `config.systemInstruction`,
         // que é o campo canônico da API — colocá-las em parts[0].text
-        // (como estava antes) mistura as regras com o conteúdo do usuário
-        // e é menos robusto contra prompt injection.
+        // mistura as regras com o conteúdo do usuário e é menos robusto
+        // contra prompt injection.
+        //
+        // Multi-part: quando o usuário envia múltiplas imagens do MESMO
+        // documento (ex: várias páginas de fatura), mandamos todas como
+        // parts na MESMA request. Isso consome UMA quota e o modelo
+        // trata como documento contínuo (ver SYSTEM_PROMPT).
         contents: [
           {
             role: "user",
-            parts: [
-              {
-                inlineData: {
-                  mimeType,
-                  data: buffer.toString("base64"),
-                },
+            parts: parts.map((p) => ({
+              inlineData: {
+                mimeType: p.mimeType,
+                data: p.buffer.toString("base64"),
               },
-            ],
+            })),
           },
         ],
         config: {

--- a/src/lib/ai-parser/invoice-parser.test.ts
+++ b/src/lib/ai-parser/invoice-parser.test.ts
@@ -132,4 +132,30 @@ describe("parseFileWithAi", () => {
     const result = await parseFileWithAi(buffer, "application/pdf", client);
     expect(result.documentConfidence).toBeUndefined();
   });
+
+  describe("multi-part (Approach C)", () => {
+    it("aceita array de parts e passa pra client.generateInvoiceStructured como array", async () => {
+      const client = mockClient(loadFixture("nubank-fatura-sample-response.json"));
+      const parts = [
+        { buffer: Buffer.from("img-1"), mimeType: "image/jpeg" },
+        { buffer: Buffer.from("img-2"), mimeType: "image/jpeg" },
+      ];
+
+      const result = await parseFileWithAi(parts, client);
+
+      expect(result.bank).toBe("Nubank");
+      expect(client.generateInvoiceStructured).toHaveBeenCalledTimes(1);
+      expect(client.generateInvoiceStructured).toHaveBeenCalledWith(parts);
+    });
+
+    it("array de 1 input ainda funciona (coerência com N=1)", async () => {
+      const client = mockClient(loadFixture("nubank-fatura-sample-response.json"));
+      const parts = [{ buffer: Buffer.from("solo"), mimeType: "application/pdf" }];
+
+      const result = await parseFileWithAi(parts, client);
+
+      expect(result.transactions.length).toBeGreaterThan(0);
+      expect(client.generateInvoiceStructured).toHaveBeenCalledWith(parts);
+    });
+  });
 });

--- a/src/lib/ai-parser/invoice-parser.ts
+++ b/src/lib/ai-parser/invoice-parser.ts
@@ -1,5 +1,5 @@
 import type { StatementParseResult, StatementTransaction } from "@/types";
-import type { GeminiClient } from "./gemini-client";
+import type { GeminiClient, GeminiInvoicePart } from "./gemini-client";
 import type { AiInvoiceOutput } from "./schema";
 
 export interface AiParseResult extends StatementParseResult {
@@ -58,12 +58,41 @@ function sanitizeDocumentConfidence(value: unknown): number | undefined {
   return value;
 }
 
+/**
+ * Parseia um arquivo único com o Gemini. Retrocompat mantida.
+ * Para múltiplos arquivos no mesmo prompt (Approach C — multi-part), use a
+ * versão array (`parts: GeminiInvoicePart[]`).
+ */
 export async function parseFileWithAi(
   buffer: Buffer,
   mimeType: string,
   client: GeminiClient
+): Promise<AiParseResult>;
+export async function parseFileWithAi(
+  parts: GeminiInvoicePart[],
+  client: GeminiClient
+): Promise<AiParseResult>;
+export async function parseFileWithAi(
+  bufferOrParts: Buffer | GeminiInvoicePart[],
+  mimeTypeOrClient: string | GeminiClient,
+  maybeClient?: GeminiClient
 ): Promise<AiParseResult> {
-  const output = await client.generateInvoiceStructured(buffer, mimeType);
+  let client: GeminiClient;
+  let output: AiInvoiceOutput;
+
+  if (Array.isArray(bufferOrParts)) {
+    // parts[], client
+    client = mimeTypeOrClient as GeminiClient;
+    output = await client.generateInvoiceStructured(bufferOrParts);
+  } else {
+    // buffer, mimeType, client
+    client = maybeClient as GeminiClient;
+    output = await client.generateInvoiceStructured(
+      bufferOrParts,
+      mimeTypeOrClient as string
+    );
+  }
+
   const transactions = sanitize(output);
 
   const discarded = output.transactions.length - transactions.length;

--- a/src/lib/ai-parser/prompt.ts
+++ b/src/lib/ai-parser/prompt.ts
@@ -1,5 +1,8 @@
 export const SYSTEM_PROMPT = `Você é um extrator de transações financeiras brasileiras. Recebe um PDF ou imagem de fatura de cartão ou extrato bancário e devolve dados estruturados no formato JSON especificado pelo schema.
 
+DOCUMENTO MULTI-IMAGEM (IMPORTANTE):
+0. O documento pode vir em MÚLTIPLAS páginas/imagens anexadas à mesma mensagem (ex: 3 prints de uma fatura longa, ou frente + verso de um extrato). Considere TODAS as imagens/páginas como UM ÚNICO documento contínuo: extraia transações de todas, deduplique linhas que aparecem em mais de uma imagem por causa de sobreposição/rolagem, e retorne o conjunto consolidado em "transactions". O "bank" e "documentType" devem refletir o documento como um todo.
+
 REGRAS GERAIS:
 1. Extraia APENAS lançamentos reais efetivos. Ignore: saldo inicial, saldo final, saldo anterior, totais, subtotais, juros informativos, limite de crédito, pontuação de cashback, ofertas, avisos de mudança de vencimento.
 

--- a/src/lib/ai-parser/prompt.ts
+++ b/src/lib/ai-parser/prompt.ts
@@ -3,6 +3,12 @@ export const SYSTEM_PROMPT = `Você é um extrator de transações financeiras b
 DOCUMENTO MULTI-IMAGEM (IMPORTANTE):
 0. O documento pode vir em MÚLTIPLAS páginas/imagens anexadas à mesma mensagem (ex: 3 prints de uma fatura longa, ou frente + verso de um extrato). Considere TODAS as imagens/páginas como UM ÚNICO documento contínuo: extraia transações de todas, deduplique linhas que aparecem em mais de uma imagem por causa de sobreposição/rolagem, e retorne o conjunto consolidado em "transactions". O "bank" e "documentType" devem refletir o documento como um todo.
 
+0a. COERÊNCIA DO BATCH: se as imagens/páginas CLARAMENTE não pertencem ao mesmo documento (ex: uma é fatura do Nubank e outra é extrato do Itaú, ou há notificações/prints independentes misturados), NÃO tente consolidar. Nesse caso, retorne:
+   - documentType: "desconhecido"
+   - transactions: []
+   - documentConfidence: <= 0.4
+   Assim o sistema processará cada imagem individualmente pelo caminho de fallback. Sinais de batch heterogêneo: bancos/logotipos diferentes entre as imagens, tipos de documento claramente distintos (ex: fatura + extrato), ou imagens que obviamente não formam um documento contínuo (ex: uma fatura inteira em 1 imagem + 1 notificação push avulsa).
+
 REGRAS GERAIS:
 1. Extraia APENAS lançamentos reais efetivos. Ignore: saldo inicial, saldo final, saldo anterior, totais, subtotais, juros informativos, limite de crédito, pontuação de cashback, ofertas, avisos de mudança de vencimento.
 

--- a/src/lib/parse-pipeline.test.ts
+++ b/src/lib/parse-pipeline.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/ocr-parser", async (importOriginal) => {
 vi.mock("@/lib/statement-parser");
 vi.mock("@/lib/notification-parser");
 
-import { parseFileForImport } from "./parse-pipeline";
+import { parseFileForImport, parseFilesForImport } from "./parse-pipeline";
 import * as aiQuota from "@/lib/rate-limit/ai-quota";
 import * as geminiClientMod from "@/lib/ai-parser/gemini-client";
 import * as invoiceParser from "@/lib/ai-parser/invoice-parser";
@@ -53,7 +53,7 @@ describe("parseFileForImport", () => {
     vi.mocked(aiQuota.release).mockResolvedValue(undefined);
     vi.mocked(notifParser.parseNotificationText).mockReturnValue(null);
     vi.mocked(geminiClientMod.createGeminiClient).mockReturnValue({
-      generateInvoiceStructured: vi.fn(),
+      generateInvoiceStructured: vi.fn() as never,
     });
     vi.mocked(invoiceParser.parseFileWithAi).mockResolvedValue(validAiResult());
     vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "", confidence: 0 });
@@ -814,5 +814,251 @@ describe("parseFileForImport", () => {
       expect(result.fallbackReason).toBeUndefined();
       expect(result.usedFallback).toBe(false);
     });
+  });
+});
+
+describe("parseFilesForImport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(aiQuota.currentYearMonth).mockReturnValue("2026-04");
+    vi.mocked(aiQuota.tryReserve).mockResolvedValue(true);
+    vi.mocked(aiQuota.release).mockResolvedValue(undefined);
+    vi.mocked(notifParser.parseNotificationText).mockReturnValue(null);
+    vi.mocked(geminiClientMod.createGeminiClient).mockReturnValue({
+      generateInvoiceStructured: vi.fn() as never,
+    });
+    vi.mocked(invoiceParser.parseFileWithAi).mockResolvedValue(validAiResult());
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "", confidence: 0 });
+    vi.mocked(ocrParser.processImageOCR).mockResolvedValue({ text: "", confidence: 0 });
+    vi.mocked(ocrParser.isPdfEncrypted).mockResolvedValue(false);
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "",
+      averageConfidence: 0,
+      transactions: [],
+    });
+  });
+
+  it("N inputs com AI: chama Gemini 1x com array de parts (uma única quota)", async () => {
+    const inputs = [1, 2, 3].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.source).toBe("ai");
+    expect(result.usedFallback).toBe(false);
+    // Chave: 1 reserva de quota pro batch inteiro
+    expect(aiQuota.tryReserve).toHaveBeenCalledTimes(1);
+    // Chave: 1 chamada ao Gemini com array de 3 parts
+    expect(invoiceParser.parseFileWithAi).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(invoiceParser.parseFileWithAi).mock.calls[0][0];
+    expect(Array.isArray(firstArg)).toBe(true);
+    expect(firstArg).toHaveLength(3);
+  });
+
+  it("AI falha: fallback roda loop imagem-por-imagem com OCR+regex (sem nova quota)", async () => {
+    vi.mocked(invoiceParser.parseFileWithAi).mockRejectedValue(new Error("gemini 5xx"));
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "EXTRATO COMPLETO", confidence: 85 });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "C6",
+      averageConfidence: 0.85,
+      transactions: [
+        { date: new Date(), description: "PIX", amount: 100, type: "INCOME", confidence: 0.85 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.source).toBe("regex");
+    expect(result.fallbackReason).toBe("ai_error");
+    expect(result.usedFallback).toBe(true);
+    // Transações agregadas dos 2 arquivos
+    expect(result.transactions).toHaveLength(2);
+    // Chave: 1 chamada à AI (que falhou), DEPOIS loop de OCR por arquivo
+    expect(invoiceParser.parseFileWithAi).toHaveBeenCalledTimes(1);
+    expect(ocrParser.processFile).toHaveBeenCalledTimes(2);
+    // Quota reservada apenas 1x
+    expect(aiQuota.tryReserve).toHaveBeenCalledTimes(1);
+  });
+
+  it("N=1 input: delega pra parseFileForImport (comportamento idêntico)", async () => {
+    // Single input passa pela implementação single-file — mantém fast-path
+    // incluindo STEP 1 notif, que o caminho multi pula.
+    vi.mocked(notifParser.parseNotificationText).mockReturnValue({
+      bank: "Nubank",
+      averageConfidence: 0.9,
+      transactions: [
+        { date: new Date(), description: "CPG IFOOD", amount: -25, type: "EXPENSE", confidence: 0.9 },
+      ],
+    });
+    vi.mocked(ocrParser.processImageOCR).mockResolvedValue({
+      text: "Compra R$25",
+      confidence: 80,
+    });
+
+    const result = await parseFilesForImport([
+      {
+        buffer: Buffer.from("single"),
+        mimeType: "image/png",
+        filename: "notif.png",
+        userId,
+      },
+    ]);
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    // Como foi N=1 e bateu com notif, resultado = fast-path (sem quota).
+    expect(result.source).toBe("notif");
+    expect(aiQuota.tryReserve).not.toHaveBeenCalled();
+    expect(invoiceParser.parseFileWithAi).not.toHaveBeenCalled();
+  });
+
+  it("N inputs sem AI (GEMINI_API_KEY ausente): loop fallback direto, nenhuma quota", async () => {
+    vi.mocked(geminiClientMod.createGeminiClient).mockReturnValue(null);
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "EXTRATO", confidence: 85 });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "C6",
+      averageConfidence: 0.85,
+      transactions: [
+        { date: new Date(), description: "PIX", amount: 100, type: "INCOME", confidence: 0.85 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.source).toBe("regex");
+    expect(result.fallbackReason).toBe("disabled");
+    expect(result.transactions).toHaveLength(2);
+    expect(aiQuota.tryReserve).not.toHaveBeenCalled();
+    expect(invoiceParser.parseFileWithAi).not.toHaveBeenCalled();
+  });
+
+  it("N inputs com quota esgotada: fallback sem chamar AI", async () => {
+    vi.mocked(aiQuota.tryReserve).mockResolvedValue(false);
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "EXTRATO", confidence: 85 });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "C6",
+      averageConfidence: 0.85,
+      transactions: [
+        { date: new Date(), description: "PIX", amount: 100, type: "INCOME", confidence: 0.85 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.source).toBe("regex");
+    expect(result.fallbackReason).toBe("quota_exhausted");
+    expect(aiQuota.tryReserve).toHaveBeenCalledTimes(1);
+    expect(invoiceParser.parseFileWithAi).not.toHaveBeenCalled();
+  });
+
+  it("PDF encriptado entre os inputs: pula AI pro batch inteiro", async () => {
+    vi.mocked(ocrParser.isPdfEncrypted).mockImplementation(async (buf: Buffer) => {
+      return buf.toString() === "locked";
+    });
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "", confidence: 0 });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "",
+      averageConfidence: 0,
+      transactions: [],
+    });
+
+    const inputs = [
+      { buffer: Buffer.from("normal"), mimeType: "application/pdf", filename: "a.pdf", userId },
+      { buffer: Buffer.from("locked"), mimeType: "application/pdf", filename: "b.pdf", userId },
+    ];
+
+    const result = await parseFilesForImport(inputs);
+
+    expect(result.kind).toBe("error");
+    expect(invoiceParser.parseFileWithAi).not.toHaveBeenCalled();
+    expect(aiQuota.tryReserve).not.toHaveBeenCalled();
+  });
+
+  it("N inputs com AI + gate reprovado: cai em fallback agregando por-arquivo", async () => {
+    vi.mocked(invoiceParser.parseFileWithAi).mockResolvedValue({
+      bank: "Desconhecido",
+      documentType: "desconhecido",
+      averageConfidence: 1,
+      transactions: [],
+    });
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "EXTRATO", confidence: 85 });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "Itau",
+      averageConfidence: 0.85,
+      transactions: [
+        { date: new Date(), description: "PIX", amount: 50, type: "INCOME", confidence: 0.85 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.source).toBe("regex");
+    expect(result.fallbackReason).toBe("gate_rejected");
+    expect(result.transactions).toHaveLength(2);
+    // AI foi chamada 1x (falhou gate) mas não 2x
+    expect(invoiceParser.parseFileWithAi).toHaveBeenCalledTimes(1);
+  });
+
+  it("input vazio: retorna invalid_file", async () => {
+    const result = await parseFilesForImport([]);
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") {
+      expect(result.error).toBe("invalid_file");
+    }
+    expect(aiQuota.tryReserve).not.toHaveBeenCalled();
+  });
+
+  it("mime inválido em QUALQUER input: invalid_file antes de reservar quota", async () => {
+    const inputs = [
+      { buffer: Buffer.from("ok"), mimeType: "image/jpeg", filename: "a.jpg", userId },
+      { buffer: Buffer.from("bad"), mimeType: "application/x-exe", filename: "b.exe", userId },
+    ];
+
+    const result = await parseFilesForImport(inputs);
+    expect(result.kind).toBe("error");
+    expect(aiQuota.tryReserve).not.toHaveBeenCalled();
+    expect(invoiceParser.parseFileWithAi).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/parse-pipeline.test.ts
+++ b/src/lib/parse-pipeline.test.ts
@@ -1061,4 +1061,122 @@ describe("parseFilesForImport", () => {
     expect(aiQuota.tryReserve).not.toHaveBeenCalled();
     expect(invoiceParser.parseFileWithAi).not.toHaveBeenCalled();
   });
+
+  it("AI + gate rejeita quando documentConfidence < 0.6 no multi-part (threshold mais alto que single)", async () => {
+    // Regressão P1: álbum com documentos heterogêneos tende a vir com
+    // confidence entre 0.5 e 0.6 (modelo tem incerteza sobre a coesão).
+    // Single-file aceita >= 0.5; multi-part usa >= 0.6 pra não mesclar
+    // bancos/tipos distintos.
+    vi.mocked(invoiceParser.parseFileWithAi).mockResolvedValue({
+      bank: "Nubank",
+      documentType: "fatura_cartao",
+      documentConfidence: 0.55, // entre 0.5 e 0.6 — rejeitado no multi-part
+      averageConfidence: 1,
+      transactions: [
+        { date: new Date(), description: "X", amount: 5, type: "EXPENSE", confidence: 1 },
+      ],
+    });
+    vi.mocked(ocrParser.processFile).mockResolvedValue({ text: "EXTRATO", confidence: 85 });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "C6",
+      averageConfidence: 0.85,
+      transactions: [
+        { date: new Date(), description: "PIX", amount: 100, type: "INCOME", confidence: 0.85 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.fallbackReason).toBe("gate_rejected");
+    expect(result.source).toBe("regex");
+    // Fallback por-arquivo rodou e agregou
+    expect(result.transactions).toHaveLength(2);
+  });
+
+  it("AI + gate aceita quando documentConfidence >= 0.6 no multi-part", async () => {
+    vi.mocked(invoiceParser.parseFileWithAi).mockResolvedValue({
+      bank: "Nubank",
+      documentType: "fatura_cartao",
+      documentConfidence: 0.65,
+      averageConfidence: 1,
+      transactions: [
+        { date: new Date(), description: "X", amount: 5, type: "EXPENSE", confidence: 1 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    expect(result.source).toBe("ai");
+    expect(result.fallbackReason).toBeUndefined();
+  });
+
+  it("fallback com TODOS inputs falhando por erro interno de OCR: retorna 'internal' (não 'no_transactions_found')", async () => {
+    // Regressão P3: se o OCR/parser interno falhar em cada arquivo do batch,
+    // a função antes retornava 'no_transactions_found' — falso negativo de
+    // negócio que mascara problema de infra. Agora deve propagar 'internal'.
+    vi.mocked(invoiceParser.parseFileWithAi).mockRejectedValue(new Error("gemini down"));
+    vi.mocked(ocrParser.processFile).mockRejectedValue(new Error("tesseract crashed"));
+
+    const inputs = [1, 2, 3].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.error).toBe("internal");
+    // Mensagem carrega o erro real pro diagnóstico
+    expect(result.message).toContain("tesseract");
+  });
+
+  it("fallback com parte dos inputs falhando mas um extraindo transações: success com as que deram certo", async () => {
+    // Contraponto do teste acima: se AO MENOS UM input extrair transações,
+    // não deve retornar 'internal' — o batch tem valor real, mesmo parcial.
+    vi.mocked(invoiceParser.parseFileWithAi).mockRejectedValue(new Error("gemini down"));
+    let callCount = 0;
+    vi.mocked(ocrParser.processFile).mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) throw new Error("tesseract crashed");
+      return { text: "EXTRATO BOM", confidence: 85 };
+    });
+    vi.mocked(statementParser.parseStatementText).mockReturnValue({
+      bank: "C6",
+      averageConfidence: 0.85,
+      transactions: [
+        { date: new Date(), description: "PIX", amount: 100, type: "INCOME", confidence: 0.85 },
+      ],
+    });
+
+    const inputs = [1, 2].map((i) => ({
+      buffer: Buffer.from(`img-${i}`),
+      mimeType: "image/jpeg",
+      filename: `img-${i}.jpg`,
+      userId,
+    }));
+
+    const result = await parseFilesForImport(inputs);
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") return;
+    // 1 input falhou, 1 extraiu — agregou o que deu
+    expect(result.transactions).toHaveLength(1);
+  });
 });

--- a/src/lib/parse-pipeline.ts
+++ b/src/lib/parse-pipeline.ts
@@ -113,6 +113,246 @@ function logParseResult(event: {
 }
 
 /**
+ * Versão multi-input do pipeline. Usada quando o usuário envia múltiplos
+ * arquivos que representam o MESMO documento (ex: várias fotos de uma mesma
+ * fatura). A IA roda UMA VEZ com todas as parts no mesmo prompt — consome
+ * apenas 1 quota para o batch inteiro.
+ *
+ * Comportamento:
+ *  - N == 1: comporta-se igual a `parseFileForImport` (compat total).
+ *  - N >= 2:
+ *    - Guards pré-IA rodam por arquivo (mime inválido, >50MB, PDF encriptado).
+ *    - STEP 1 (notif fast-path) é PULADO — só faz sentido para imagem única.
+ *    - STEP 2: se AI disponível e nenhum arquivo for PDF criptografado, reserva
+ *      quota 1x e chama AI com o array.
+ *    - STEP 3: se AI falhar/pular, cai em loop fallback (OCR+regex) arquivo-por-arquivo,
+ *      AGREGANDO transações de todos.
+ *    - O resultado é UM ParseResult único; fallbackReason = primeiro observado.
+ *
+ * PDFs criptografados em ANY arquivo: pulam a AI pro batch inteiro.
+ */
+export async function parseFilesForImport(
+  inputs: ParseInput[]
+): Promise<ParseResult> {
+  if (inputs.length === 0) {
+    return {
+      kind: "error",
+      error: "invalid_file",
+      message: "Nenhum arquivo fornecido",
+    };
+  }
+  if (inputs.length === 1) {
+    return parseFileForImport(inputs[0]);
+  }
+
+  const startedAt = Date.now();
+  const userId = inputs[0].userId;
+  const yearMonth = currentYearMonth();
+
+  // Guards pré-IA por arquivo
+  for (const inp of inputs) {
+    if (!VALID_MIMES.has(inp.mimeType)) {
+      return {
+        kind: "error",
+        error: "invalid_file",
+        message: `Tipo de arquivo não suportado: ${inp.filename}`,
+      };
+    }
+    if (inp.buffer.byteLength > MAX_BYTES) {
+      return {
+        kind: "error",
+        error: "invalid_file",
+        message: `Arquivo excede 50 MB: ${inp.filename}`,
+      };
+    }
+  }
+
+  // PREFLIGHT: se QUALQUER PDF for encriptado, pula a AI pro batch
+  let anyEncryptedPdf = false;
+  for (const inp of inputs) {
+    if (inp.mimeType === "application/pdf") {
+      try {
+        if (await isPdfEncrypted(inp.buffer)) {
+          anyEncryptedPdf = true;
+          break;
+        }
+      } catch {
+        // Se preflight quebrar, seguir assumindo não-criptografado (AI decide)
+      }
+    }
+  }
+
+  const client = !anyEncryptedPdf ? createGeminiClient() : null;
+  const aiEnabled = client !== null;
+
+  let fallbackReason: FallbackReason | null = null;
+  let aiAttempted = false;
+  let quotaReserved = false;
+
+  if (anyEncryptedPdf) {
+    fallbackReason = "pdf_encrypted";
+  } else if (!aiEnabled) {
+    fallbackReason = "disabled";
+  }
+
+  // STEP 2 MULTI-PART: reserva 1 quota, chama AI com array de parts
+  if (client) {
+    try {
+      quotaReserved = await tryReserve(userId, yearMonth);
+      if (!quotaReserved) {
+        fallbackReason = "quota_exhausted";
+      }
+    } catch (err) {
+      console.warn(
+        "tryReserve falhou (multi), caindo em fallback:",
+        err instanceof Error ? err.message : String(err)
+      );
+      quotaReserved = false;
+      fallbackReason = "quota_error";
+    }
+
+    if (quotaReserved) {
+      aiAttempted = true;
+      try {
+        const aiResult = await parseFileWithAi(
+          inputs.map((inp) => ({ buffer: inp.buffer, mimeType: inp.mimeType })),
+          client
+        );
+
+        const validDocType =
+          aiResult.documentType === "fatura_cartao" ||
+          aiResult.documentType === "extrato_bancario";
+
+        const confidenceOk =
+          aiResult.documentConfidence === undefined ||
+          aiResult.documentConfidence >= 0.5;
+
+        if (validDocType && aiResult.transactions.length > 0 && confidenceOk) {
+          logParseResult({
+            source: "ai",
+            documentType: aiResult.documentType,
+            txCount: aiResult.transactions.length,
+            latencyMs: Date.now() - startedAt,
+            mimeType: `multi(${inputs.length})`,
+            quotaReserved: true,
+          });
+          return {
+            kind: "success",
+            bank: aiResult.bank,
+            transactions: aiResult.transactions,
+            source: "ai",
+            usedFallback: false,
+            aiEnabled: true,
+            aiAttempted: true,
+            confidence: aiResult.averageConfidence,
+          };
+        }
+        fallbackReason = "gate_rejected";
+      } catch (err) {
+        console.warn(
+          "AI multi-part falhou, caindo em fallback por-arquivo:",
+          err instanceof Error ? err.message : String(err)
+        );
+        fallbackReason = "ai_error";
+      }
+    }
+  }
+
+  // STEP 3 FALLBACK: loop arquivo-por-arquivo. IMPORTANTE — a partir daqui,
+  // NÃO re-chamamos a IA por item (ela já foi tentada/pulada uma vez no batch).
+  // Portanto cada item roda apenas OCR + regex/notif, sem quota extra.
+  if (fallbackReason === null) {
+    fallbackReason = "ai_error";
+  }
+
+  const aggregatedTx: StatementParseResult["transactions"] = [];
+  let aggregatedBank = "";
+  let aggregatedConfidenceSum = 0;
+  let aggregatedConfidenceCount = 0;
+  let aggregatedRawText = "";
+
+  for (const inp of inputs) {
+    try {
+      // PDF criptografado + fallback: processFile pode lançar PdfPasswordError.
+      const ocrResult = await processFile(
+        bufferToFile(inp.buffer, inp.filename, inp.mimeType),
+        inp.password
+      );
+
+      const statementResult = parseStatementText(
+        ocrResult.text,
+        ocrResult.confidence
+      );
+      if (statementResult.transactions.length > 0) {
+        if (!aggregatedBank) aggregatedBank = statementResult.bank;
+        aggregatedTx.push(...statementResult.transactions);
+        aggregatedConfidenceSum += statementResult.averageConfidence;
+        aggregatedConfidenceCount++;
+        aggregatedRawText += ocrResult.text + "\n";
+        continue;
+      }
+
+      const notifResult = parseNotificationText(
+        ocrResult.text,
+        ocrResult.confidence
+      );
+      if (notifResult && notifResult.transactions.length > 0) {
+        if (!aggregatedBank) aggregatedBank = notifResult.bank;
+        aggregatedTx.push(...notifResult.transactions);
+        aggregatedConfidenceSum += notifResult.averageConfidence;
+        aggregatedConfidenceCount++;
+        aggregatedRawText += ocrResult.text + "\n";
+      }
+    } catch (err) {
+      if (err instanceof PdfPasswordError) {
+        return {
+          kind: "error",
+          error: err.needsPassword ? "needs_password" : "wrong_password",
+        };
+      }
+      // Erro de OCR em um item individual — pula e continua agregando.
+      console.warn(
+        `Erro processando ${inp.filename} no fallback multi:`,
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+  }
+
+  if (aggregatedTx.length > 0) {
+    const avgConfidence =
+      aggregatedConfidenceCount > 0
+        ? aggregatedConfidenceSum / aggregatedConfidenceCount
+        : 0;
+    logParseResult({
+      source: "regex",
+      fallbackReason,
+      txCount: aggregatedTx.length,
+      latencyMs: Date.now() - startedAt,
+      mimeType: `multi(${inputs.length})`,
+      quotaReserved,
+    });
+    return {
+      kind: "success",
+      bank: aggregatedBank,
+      transactions: aggregatedTx,
+      source: "regex",
+      usedFallback: true,
+      aiEnabled,
+      aiAttempted,
+      fallbackReason,
+      confidence: avgConfidence,
+      rawText: aggregatedRawText || undefined,
+    };
+  }
+
+  return {
+    kind: "error",
+    error: "no_transactions_found",
+    rawText: aggregatedRawText || undefined,
+  };
+}
+
+/**
  * Pipeline unificado de extração de transações a partir de arquivos
  * (PDF, imagens de extratos, fotos de notificações bancárias).
  *

--- a/src/lib/parse-pipeline.ts
+++ b/src/lib/parse-pipeline.ts
@@ -223,9 +223,14 @@ export async function parseFilesForImport(
           aiResult.documentType === "fatura_cartao" ||
           aiResult.documentType === "extrato_bancario";
 
+        // Threshold mais alto que o single-file (0.5) porque em batches
+        // heterogêneos (álbum com docs diferentes) o modelo tende a devolver
+        // confidence intermediário. Rejeitar sub-0.6 aqui faz o fallback
+        // processar imagem por imagem, evitando mesclar bancos/docs distintos.
+        const MULTI_PART_CONFIDENCE_THRESHOLD = 0.6;
         const confidenceOk =
           aiResult.documentConfidence === undefined ||
-          aiResult.documentConfidence >= 0.5;
+          aiResult.documentConfidence >= MULTI_PART_CONFIDENCE_THRESHOLD;
 
         if (validDocType && aiResult.transactions.length > 0 && confidenceOk) {
           logParseResult({
@@ -270,6 +275,12 @@ export async function parseFilesForImport(
   let aggregatedConfidenceSum = 0;
   let aggregatedConfidenceCount = 0;
   let aggregatedRawText = "";
+  // Rastreia falhas internas de OCR/parse (não PdfPasswordError) pra
+  // distinguir "ausência real de transações" de "falha de infra que mascarou
+  // transações". Se TODOS os itens falharem assim, retornamos "internal"
+  // em vez de "no_transactions_found" (que seria falso negativo de negócio).
+  let internalFailures = 0;
+  let lastInternalError: string | undefined;
 
   for (const inp of inputs) {
     try {
@@ -310,10 +321,14 @@ export async function parseFilesForImport(
           error: err.needsPassword ? "needs_password" : "wrong_password",
         };
       }
-      // Erro de OCR em um item individual — pula e continua agregando.
+      // Erro de OCR em um item individual — registra pro diagnóstico final.
+      // Se pelo menos um outro item extrair transações, seguimos com sucesso.
+      // Se TODOS falharem assim, retornamos "internal" (não "no_transactions_found").
+      internalFailures++;
+      lastInternalError = err instanceof Error ? err.message : String(err);
       console.warn(
         `Erro processando ${inp.filename} no fallback multi:`,
-        err instanceof Error ? err.message : String(err)
+        lastInternalError
       );
     }
   }
@@ -342,6 +357,17 @@ export async function parseFilesForImport(
       fallbackReason,
       confidence: avgConfidence,
       rawText: aggregatedRawText || undefined,
+    };
+  }
+
+  // Se TODOS os itens falharam por erro interno (OCR quebrado, parser quebrado,
+  // lib indisponível), propaga como "internal" pra não mascarar problema de
+  // infra como se fosse "documento sem transações".
+  if (internalFailures === inputs.length) {
+    return {
+      kind: "error",
+      error: "internal",
+      message: lastInternalError ?? "Erro ao processar arquivos",
     };
   }
 

--- a/src/lib/telegram/commands.test.ts
+++ b/src/lib/telegram/commands.test.ts
@@ -42,6 +42,7 @@ vi.mock("./client", () => ({
 
 vi.mock("@/lib/parse-pipeline", () => ({
   parseFileForImport: vi.fn(),
+  parseFilesForImport: vi.fn(),
 }))
 
 vi.mock("@/lib/dedup", async (importOriginal) => {
@@ -86,7 +87,7 @@ import {
   handlePhotoBackToSummary,
 } from "./commands"
 import type { TelegramMessage } from "./client"
-import { parseFileForImport } from "@/lib/parse-pipeline"
+import { parseFileForImport, parseFilesForImport } from "@/lib/parse-pipeline"
 import { suggestCategory } from "@/lib/categorizer"
 import { filterDuplicates } from "@/lib/dedup"
 import { importTransactions } from "@/lib/import-service"
@@ -97,6 +98,7 @@ const mockEditMessageText = vi.mocked(editMessageText)
 const mockGetFile = vi.mocked(getFile)
 const mockDownloadFileBuffer = vi.mocked(downloadFileBuffer)
 const mockParsePipeline = vi.mocked(parseFileForImport)
+const mockParseFilesForImport = vi.mocked(parseFilesForImport)
 const mockSuggestCategory = vi.mocked(suggestCategory)
 const mockFilterDuplicates = vi.mocked(filterDuplicates)
 const mockImportTransactions = vi.mocked(importTransactions)
@@ -1231,6 +1233,202 @@ describe("handlePhotoMessage - media group batching", () => {
     const text = (lastEdit?.[2] ?? mockSendMessage.mock.calls.at(-1)?.[1] ?? "") as string
     expect(text).not.toContain("IA ·")
     expect(text).not.toContain("parser tradicional")
+  })
+
+  // Approach C — Gemini Multi-Part: testa que múltiplas fotos + AI habilitada
+  // consomem 1 chamada ao Gemini (via parseFilesForImport) pro batch inteiro.
+  describe("Approach C — unified multi-part when N>=2 + AI enabled", () => {
+    let originalGeminiKey: string | undefined
+
+    beforeEach(() => {
+      originalGeminiKey = process.env.GEMINI_API_KEY
+      process.env.GEMINI_API_KEY = "test-key"
+    })
+
+    afterEach(() => {
+      if (originalGeminiKey === undefined) {
+        delete process.env.GEMINI_API_KEY
+      } else {
+        process.env.GEMINI_API_KEY = originalGeminiKey
+      }
+    })
+
+    it("batch com 3 imagens + AI habilitada: chama parseFilesForImport 1x com 3 inputs", async () => {
+      const msg = makePhotoMessage()
+      msg.media_group_id = "group-unified-3"
+
+      vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+      vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 3 } as never)
+      vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+        { id: "q1", fileId: "uni-a", mediaGroupId: "group-unified-3", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+        { id: "q2", fileId: "uni-b", mediaGroupId: "group-unified-3", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+        { id: "q3", fileId: "uni-c", mediaGroupId: "group-unified-3", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      ] as never)
+      vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 3 } as never)
+
+      mockGetFile.mockResolvedValue("photos/file.jpg")
+      mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake-img"))
+      mockParseFilesForImport.mockResolvedValue({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [
+          { date: new Date(), description: "IFOOD", amount: 30, type: "EXPENSE", confidence: 1 },
+          { date: new Date(), description: "UBER", amount: 18, type: "EXPENSE", confidence: 1 },
+          { date: new Date(), description: "SPOTIFY", amount: 22, type: "EXPENSE", confidence: 1 },
+        ],
+        source: "ai",
+        usedFallback: false,
+        aiEnabled: true,
+        aiAttempted: true,
+        confidence: 1,
+      })
+      mockSuggestCategory.mockResolvedValue(null)
+      mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+        unique: txs.map(t => ({ ...t, selected: true })),
+        duplicateCount: 0,
+      }) as never)
+      mockGetUsage.mockResolvedValue({ used: 1, remaining: 4, limit: 5 })
+      vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+      vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "pending-uni" } as never)
+      mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+      mockEditMessageText.mockResolvedValue({ ok: true })
+
+      const promise = handlePhotoMessage(msg, "user-1")
+      await vi.advanceTimersByTimeAsync(3000)
+      await promise
+
+      // CHAVE: parseFilesForImport chamado EXATAMENTE 1 VEZ com 3 inputs
+      expect(mockParseFilesForImport).toHaveBeenCalledTimes(1)
+      const call = mockParseFilesForImport.mock.calls[0][0]
+      expect(call).toHaveLength(3)
+      expect(call[0]).toMatchObject({
+        mimeType: "image/jpeg",
+        userId: "user-1",
+      })
+      // E o caminho legado NÃO foi usado
+      expect(mockParsePipeline).not.toHaveBeenCalled()
+      // Downloads aconteceram (em paralelo) pros 3 arquivos
+      expect(mockGetFile).toHaveBeenCalledTimes(3)
+      expect(mockDownloadFileBuffer).toHaveBeenCalledTimes(3)
+      // Mensagem de progresso reflete unificação
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        12345,
+        expect.stringContaining("Unificando 3 imagens")
+      )
+      // Resumo final usa badge de AI + contador
+      const lastEdit = mockEditMessageText.mock.calls[mockEditMessageText.mock.calls.length - 1]
+      const finalText = String(lastEdit?.[2] ?? "")
+      expect(finalText).toContain("✨")
+      expect(finalText).toContain("IA · 1/5")
+      expect(finalText).toContain("3 transações")
+    })
+
+    it("batch com 3 imagens mas AI desabilitada: mantém loop sequencial (não unifica)", async () => {
+      // Com AI desabilitada, não há por que unificar (não economiza quota).
+      delete process.env.GEMINI_API_KEY
+
+      const msg = makePhotoMessage()
+      msg.media_group_id = "group-no-ai-3"
+
+      vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+      vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 3 } as never)
+      vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+        { id: "q1", fileId: "na-a", mediaGroupId: "group-no-ai-3", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+        { id: "q2", fileId: "na-b", mediaGroupId: "group-no-ai-3", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+        { id: "q3", fileId: "na-c", mediaGroupId: "group-no-ai-3", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      ] as never)
+      vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 3 } as never)
+
+      mockGetFile.mockResolvedValue("photos/file.jpg")
+      mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake"))
+      mockParsePipeline.mockResolvedValue({
+        kind: "success",
+        bank: "C6",
+        transactions: [
+          { date: new Date(), description: "PIX", amount: 100, type: "INCOME", confidence: 0.85 },
+        ],
+        source: "regex",
+        usedFallback: true,
+        aiEnabled: false,
+        aiAttempted: false,
+        fallbackReason: "disabled",
+        confidence: 0.85,
+      })
+      mockSuggestCategory.mockResolvedValue(null)
+      mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+        unique: txs.map(t => ({ ...t, selected: true })),
+        duplicateCount: 0,
+      }) as never)
+      vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+      vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "pending-na" } as never)
+      mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+      mockEditMessageText.mockResolvedValue({ ok: true })
+
+      const promise = handlePhotoMessage(msg, "user-1")
+      await vi.advanceTimersByTimeAsync(3000)
+      await promise
+
+      // CHAVE: parseFilesForImport NUNCA foi chamado
+      expect(mockParseFilesForImport).not.toHaveBeenCalled()
+      // Loop sequencial chamou parseFileForImport 3x
+      expect(mockParsePipeline).toHaveBeenCalledTimes(3)
+      // Mensagem de progresso é a tradicional
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        12345,
+        expect.stringContaining("Processando imagem 1 de 3")
+      )
+    })
+
+    it("batch com 1 imagem + AI habilitada: NÃO unifica (caminho legacy single)", async () => {
+      const msg = makePhotoMessage()
+      // Sem media_group_id: vira single_<message_id>
+
+      vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+      vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 1 } as never)
+      vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+        { id: "q1", fileId: "solo", mediaGroupId: "single_1", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      ] as never)
+      vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 1 } as never)
+
+      mockGetFile.mockResolvedValue("photos/file.jpg")
+      mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake"))
+      mockParsePipeline.mockResolvedValue({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [
+          { date: new Date(), description: "PAG", amount: 10, type: "EXPENSE", confidence: 1 },
+        ],
+        source: "ai",
+        usedFallback: false,
+        aiEnabled: true,
+        aiAttempted: true,
+        confidence: 1,
+      })
+      mockSuggestCategory.mockResolvedValue(null)
+      mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+        unique: txs.map(t => ({ ...t, selected: true })),
+        duplicateCount: 0,
+      }) as never)
+      mockGetUsage.mockResolvedValue({ used: 1, remaining: 4, limit: 5 })
+      vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+      vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "pending-solo" } as never)
+      mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+      mockEditMessageText.mockResolvedValue({ ok: true })
+
+      const promise = handlePhotoMessage(msg, "user-1")
+      await vi.advanceTimersByTimeAsync(3000)
+      await promise
+
+      // CHAVE: parseFilesForImport NUNCA chamado (N<2 não justifica unificação)
+      expect(mockParseFilesForImport).not.toHaveBeenCalled()
+      // Caminho single usa parseFileForImport como sempre
+      expect(mockParsePipeline).toHaveBeenCalledTimes(1)
+      // Progress tradicional
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        12345,
+        expect.stringContaining("Processando imagem 1 de 1")
+      )
+    })
   })
 })
 

--- a/src/lib/telegram/commands.test.ts
+++ b/src/lib/telegram/commands.test.ts
@@ -1189,6 +1189,80 @@ describe("handlePhotoMessage - media group batching", () => {
     }
   })
 
+  it("Phase 1: persiste messageId do Telegram no create da queue (fonte de ordem estável)", async () => {
+    // Regressão P2: sem messageId persistido, o orderBy por createdAt pode
+    // empatar quando N webhooks chegam quase simultaneamente e entregar as
+    // páginas do álbum fora de ordem pro caminho multi-part.
+    const msg = makePhotoMessage()
+    msg.message_id = 42
+    msg.media_group_id = "group-order"
+
+    vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 0 } as never) // outro handler ganhou; só testamos create
+
+    const promise = handlePhotoMessage(msg, "user-1")
+    await vi.advanceTimersByTimeAsync(3000)
+    await promise
+
+    expect(prisma.telegramPhotoQueue.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          messageId: 42,
+          mediaGroupId: "group-order",
+        }),
+      })
+    )
+  })
+
+  it("Phase 3: orderBy usa messageId primeiro, createdAt e id como tiebreak", async () => {
+    // Regressão P2: ordem do álbum deve ser reconstruída por messageId
+    // (monotônico no Telegram) — createdAt e id são apenas tiebreaks.
+    const msg = makePhotoMessage()
+    msg.media_group_id = "group-order-check"
+
+    vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 1 } as never)
+    vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+      { id: "q1", fileId: "a", mediaGroupId: "group-order-check", chatId: "12345", userId: "user-1", messageId: 10, claimed: true, createdAt: new Date() },
+    ] as never)
+    vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 1 } as never)
+    mockGetFile.mockResolvedValue("photos/x.jpg")
+    mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake"))
+    mockParsePipeline.mockResolvedValue({
+      kind: "success",
+      bank: "X",
+      transactions: [{ date: new Date(), description: "T", amount: 1, type: "EXPENSE", confidence: 1 }],
+      source: "ai",
+      usedFallback: false,
+      aiEnabled: true,
+      aiAttempted: true,
+      confidence: 1,
+    })
+    mockSuggestCategory.mockResolvedValue(null)
+    mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+      unique: txs.map(t => ({ ...t, selected: true })),
+      duplicateCount: 0,
+    }) as never)
+    vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+    vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "p" } as never)
+    mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+    mockEditMessageText.mockResolvedValue({ ok: true })
+
+    const promise = handlePhotoMessage(msg, "user-1")
+    await vi.advanceTimersByTimeAsync(3000)
+    await promise
+
+    expect(prisma.telegramPhotoQueue.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [
+          { messageId: "asc" },
+          { createdAt: "asc" },
+          { id: "asc" },
+        ],
+      })
+    )
+  })
+
   it("não adiciona linha de IA quando source='notif'", async () => {
     const msg = makePhotoMessage()
     msg.media_group_id = "group-notif"

--- a/src/lib/telegram/commands.test.ts
+++ b/src/lib/telegram/commands.test.ts
@@ -966,6 +966,227 @@ describe("handlePhotoMessage - media group batching", () => {
     expect(text).toContain("IA não reconheceu")
   })
 
+  it("multi-imagem + AI habilitada: processa N fotos, agrega transações e mostra contador de uso", async () => {
+    // Regressão do caso reportado pelo usuário: antes da feature de AI, múltiplas
+    // imagens via Telegram rodavam "eternamente" (webhook síncrono vs timeout).
+    // Agora com AI on, o loop sequencial deve processar todas, agregar, e terminar
+    // com resumo único mostrando IA usada e contador de quota.
+    const msg = makePhotoMessage()
+    msg.media_group_id = "group-multi-ai"
+
+    vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 3 } as never)
+    vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+      { id: "q1", fileId: "ai-a", mediaGroupId: "group-multi-ai", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      { id: "q2", fileId: "ai-b", mediaGroupId: "group-multi-ai", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      { id: "q3", fileId: "ai-c", mediaGroupId: "group-multi-ai", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+    ] as never)
+    vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 3 } as never)
+
+    mockGetFile.mockResolvedValue("photos/file.jpg")
+    mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake"))
+    mockParsePipeline
+      .mockResolvedValueOnce({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [{ date: new Date(), description: "IFOOD", amount: 30, type: "EXPENSE", confidence: 1 }],
+        source: "ai",
+        usedFallback: false,
+        aiEnabled: true,
+        aiAttempted: true,
+        confidence: 1,
+      })
+      .mockResolvedValueOnce({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [{ date: new Date(), description: "UBER", amount: 18, type: "EXPENSE", confidence: 1 }],
+        source: "ai",
+        usedFallback: false,
+        aiEnabled: true,
+        aiAttempted: true,
+        confidence: 1,
+      })
+      .mockResolvedValueOnce({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [{ date: new Date(), description: "SPOTIFY", amount: 22, type: "EXPENSE", confidence: 1 }],
+        source: "ai",
+        usedFallback: false,
+        aiEnabled: true,
+        aiAttempted: true,
+        confidence: 1,
+      })
+    mockSuggestCategory.mockResolvedValue(null)
+    mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+      unique: txs.map(t => ({ ...t, selected: true })),
+      duplicateCount: 0,
+    }) as never)
+    mockGetUsage.mockResolvedValue({ used: 3, remaining: 2, limit: 5 })
+    vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+    vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "pending-multi-ai" } as never)
+    mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+    mockEditMessageText.mockResolvedValue({ ok: true })
+
+    const promise = handlePhotoMessage(msg, "user-1")
+    await vi.advanceTimersByTimeAsync(3000)
+    await promise
+
+    // Todas as 3 fotos foram baixadas e parseadas (loop não travou)
+    expect(mockGetFile).toHaveBeenCalledTimes(3)
+    expect(mockParsePipeline).toHaveBeenCalledTimes(3)
+    // Progress inicial + 2 edits intermediários (não edita depois da última)
+    expect(mockSendMessage).toHaveBeenCalledWith(12345, expect.stringContaining("Processando imagem 1 de 3"))
+    const progressEdits = mockEditMessageText.mock.calls.filter(c => String(c[2] ?? "").includes("Processando imagem"))
+    expect(progressEdits).toHaveLength(2)
+    // Resumo final: 3 transações agregadas, badge AI + contador, queue limpa
+    const lastEdit = mockEditMessageText.mock.calls[mockEditMessageText.mock.calls.length - 1]
+    const finalText = String(lastEdit?.[2] ?? "")
+    expect(finalText).toContain("✨")
+    expect(finalText).toContain("3 transações")
+    expect(finalText).toContain("IA · 3/5")
+    expect(prisma.telegramPhotoQueue.deleteMany).toHaveBeenCalledWith({ where: { mediaGroupId: "group-multi-ai", userId: "user-1" } })
+  })
+
+  it("multi-imagem + AI: quota esgota no meio do batch, loop continua e resumo mostra fallback", async () => {
+    // Edge case importante: usuário manda 3 fotos, quota permite 1 uso, as outras
+    // 2 caem no parser tradicional. Loop NÃO deve abortar — cada foto é independente
+    // e o fallbackReason agregado é o primeiro observado (quota_exhausted).
+    const msg = makePhotoMessage()
+    msg.media_group_id = "group-multi-quota"
+
+    vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 3 } as never)
+    vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+      { id: "q1", fileId: "mq-a", mediaGroupId: "group-multi-quota", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      { id: "q2", fileId: "mq-b", mediaGroupId: "group-multi-quota", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      { id: "q3", fileId: "mq-c", mediaGroupId: "group-multi-quota", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+    ] as never)
+    vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 3 } as never)
+
+    mockGetFile.mockResolvedValue("photos/file.jpg")
+    mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake"))
+    mockParsePipeline
+      .mockResolvedValueOnce({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [{ date: new Date(), description: "IFOOD", amount: 30, type: "EXPENSE", confidence: 1 }],
+        source: "ai",
+        usedFallback: false,
+        aiEnabled: true,
+        aiAttempted: true,
+        confidence: 1,
+      })
+      .mockResolvedValueOnce({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [{ date: new Date(), description: "UBER", amount: 18, type: "EXPENSE", confidence: 0.8 }],
+        source: "regex",
+        usedFallback: true,
+        aiEnabled: true,
+        aiAttempted: false,
+        fallbackReason: "quota_exhausted",
+        confidence: 0.8,
+      })
+      .mockResolvedValueOnce({
+        kind: "success",
+        bank: "Nubank",
+        transactions: [{ date: new Date(), description: "SPOTIFY", amount: 22, type: "EXPENSE", confidence: 0.8 }],
+        source: "regex",
+        usedFallback: true,
+        aiEnabled: true,
+        aiAttempted: false,
+        fallbackReason: "quota_exhausted",
+        confidence: 0.8,
+      })
+    mockSuggestCategory.mockResolvedValue(null)
+    mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+      unique: txs.map(t => ({ ...t, selected: true })),
+      duplicateCount: 0,
+    }) as never)
+    vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+    vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "pending-multi-quota" } as never)
+    mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+    mockEditMessageText.mockResolvedValue({ ok: true })
+
+    const promise = handlePhotoMessage(msg, "user-1")
+    await vi.advanceTimersByTimeAsync(3000)
+    await promise
+
+    // Loop não abortou: 3 fotos processadas mesmo com mistura ai + fallback
+    expect(mockGetFile).toHaveBeenCalledTimes(3)
+    expect(mockParsePipeline).toHaveBeenCalledTimes(3)
+    // Resumo informa fallback (prioridade temporal do primeiro observado = quota_exhausted)
+    // e agrega as 3 transações (tanto as de AI quanto as de fallback).
+    const lastEdit = mockEditMessageText.mock.calls[mockEditMessageText.mock.calls.length - 1]
+    const finalText = String(lastEdit?.[2] ?? "")
+    expect(finalText).toContain("Cota de IA esgotada")
+    expect(finalText).toContain("3 transações")
+    expect(finalText).not.toContain("IA · ") // não mostra contador quando tem fallbackReason
+    expect(prisma.telegramPhotoQueue.deleteMany).toHaveBeenCalledWith({ where: { mediaGroupId: "group-multi-quota", userId: "user-1" } })
+  })
+
+  it("multi-imagem: uma foto falhando (parse error) não aborta o batch — outras continuam", async () => {
+    // Garantia: se 1 de N fotos falhar no pipeline, o loop registra o erro e
+    // segue processando as demais. Usuário recebe resumo com as que sucederam.
+    const msg = makePhotoMessage()
+    msg.media_group_id = "group-partial-fail"
+
+    vi.mocked(prisma.telegramPhotoQueue.create).mockResolvedValue({} as never)
+    vi.mocked(prisma.telegramPhotoQueue.updateMany).mockResolvedValue({ count: 3 } as never)
+    vi.mocked(prisma.telegramPhotoQueue.findMany).mockResolvedValue([
+      { id: "q1", fileId: "pf-a", mediaGroupId: "group-partial-fail", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      { id: "q2", fileId: "pf-b", mediaGroupId: "group-partial-fail", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+      { id: "q3", fileId: "pf-c", mediaGroupId: "group-partial-fail", chatId: "12345", userId: "user-1", claimed: true, createdAt: new Date() },
+    ] as never)
+    vi.mocked(prisma.telegramPhotoQueue.deleteMany).mockResolvedValue({ count: 3 } as never)
+
+    mockGetFile.mockResolvedValue("photos/file.jpg")
+    mockDownloadFileBuffer.mockResolvedValue(Buffer.from("fake"))
+    const okResult = {
+      kind: "success" as const,
+      bank: "Nubank",
+      transactions: [{ date: new Date(), description: "IFOOD", amount: 30, type: "EXPENSE" as const, confidence: 1 }],
+      source: "ai" as const,
+      usedFallback: false,
+      aiEnabled: true,
+      aiAttempted: true,
+      confidence: 1,
+    }
+    mockParsePipeline
+      .mockResolvedValueOnce(okResult)
+      .mockRejectedValueOnce(new Error("OCR falhou pra essa imagem"))
+      .mockResolvedValueOnce(okResult)
+    mockSuggestCategory.mockResolvedValue(null)
+    mockFilterDuplicates.mockImplementation(async (_userId, txs) => ({
+      unique: txs.map(t => ({ ...t, selected: true })),
+      duplicateCount: 0,
+    }) as never)
+    mockGetUsage.mockResolvedValue({ used: 2, remaining: 3, limit: 5 })
+    vi.mocked(prisma.telegramPendingImport.deleteMany).mockResolvedValue({ count: 0 } as never)
+    vi.mocked(prisma.telegramPendingImport.create).mockResolvedValue({ id: "pending-pf" } as never)
+    mockSendMessage.mockResolvedValue({ result: { message_id: 99 } })
+    mockEditMessageText.mockResolvedValue({ ok: true })
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    try {
+      const promise = handlePhotoMessage(msg, "user-1")
+      await vi.advanceTimersByTimeAsync(3000)
+      await promise
+
+      // Todas as 3 tentativas ocorreram, apesar do erro na 2ª
+      expect(mockParsePipeline).toHaveBeenCalledTimes(3)
+      // Resumo final mostra 2 transações (fotos 1 e 3), batch não foi abortado
+      const lastEdit = mockEditMessageText.mock.calls[mockEditMessageText.mock.calls.length - 1]
+      const finalText = String(lastEdit?.[2] ?? "")
+      expect(finalText).toContain("2 transações")
+      expect(finalText).not.toContain("Erro ao processar as imagens")
+      // Erro da foto 2 foi logado
+      expect(errSpy).toHaveBeenCalled()
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+
   it("não adiciona linha de IA quando source='notif'", async () => {
     const msg = makePhotoMessage()
     msg.media_group_id = "group-notif"

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -15,7 +15,7 @@ import { parseCSV, detectBankFromContent } from "@/lib/csv-parser"
 import { suggestCategory, detectInstallment } from "@/lib/categorizer"
 import { findDuplicate, filterDuplicates, deduplicateTransactions } from "@/lib/dedup"
 import { importTransactions } from "@/lib/import-service"
-import { parseFileForImport } from "@/lib/parse-pipeline"
+import { parseFileForImport, parseFilesForImport } from "@/lib/parse-pipeline"
 import { getUsage } from "@/lib/rate-limit/ai-quota"
 import { formatCurrency } from "@/lib/utils"
 import {
@@ -784,71 +784,146 @@ export async function handlePhotoMessage(
       | "pdf_encrypted"
       | undefined = undefined
 
+    // Approach C — Gemini Multi-Part: quando o usuário manda múltiplas fotos
+    // E a IA está habilitada, tratamos todas como UM único documento e
+    // consumimos 1 quota pro batch. Isso fecha o vazamento de quota em que
+    // cada foto consumia 1 uso mesmo sendo páginas de uma mesma fatura.
+    const aiEnabledEnv = (process.env.GEMINI_API_KEY ?? null) !== null
+    const useUnifiedMultiPart = queueItems.length >= 2 && aiEnabledEnv
+
     // Send initial progress message
-    const progressMsg = await sendMessage(chatId, `📸 Processando imagem 1 de ${totalPhotos}...`)
+    const progressInitial = useUnifiedMultiPart
+      ? `📸 Unificando ${totalPhotos} imagens em documento único...`
+      : `📸 Processando imagem 1 de ${totalPhotos}...`
+    const progressMsg = await sendMessage(chatId, progressInitial)
     const progressMessageId = progressMsg?.result?.message_id
 
-    for (let i = 0; i < queueItems.length; i++) {
-      const item = queueItems[i]
-
-      try {
-        // Download photo
-        const filePath = await getFile(item.fileId)
-        if (!filePath) continue
-        const buffer = await downloadFileBuffer(filePath)
-
-        // Parse via pipeline unificado (notif → AI → regex)
-        const parsed = await parseFileForImport({
-          buffer,
-          mimeType: "image/jpeg", // Telegram photos come as JPEG
-          filename: `telegram-${item.fileId}.jpg`,
-          userId,
+    if (useUnifiedMultiPart) {
+      // Download todos os buffers em paralelo (reduz latência).
+      const downloads = await Promise.all(
+        queueItems.map(async (item) => {
+          try {
+            const filePath = await getFile(item.fileId)
+            if (!filePath) return null
+            const buffer = await downloadFileBuffer(filePath)
+            return { buffer, item }
+          } catch (err) {
+            console.error(`Error downloading photo ${item.fileId}:`, err)
+            return null
+          }
         })
+      )
+      const ok = downloads.filter((d): d is { buffer: Buffer; item: typeof queueItems[number] } => d !== null)
 
-        if (parsed.kind === "error") {
-          // Tracking: se uma foto falhar, pula mas continua o batch.
-          console.warn(`Telegram photo parse failed: ${parsed.error}`)
-          continue
-        }
-
-        if (parsed.bank) lastBank = parsed.bank
-        if (parsed.source === "ai") batchUsedAi = true
-        // Captura o primeiro fallbackReason do batch (prioridade temporal).
-        if (parsed.fallbackReason && !batchFallbackReason) {
-          batchFallbackReason = parsed.fallbackReason
-        }
-
-        // Categorize
-        for (const t of parsed.transactions) {
-          const suggested = await suggestCategory(t.description, userId)
-          const installment = detectInstallment(t.description)
-
-          allTransactions.push({
-            description: t.description,
-            amount: t.type === "EXPENSE" ? -Math.abs(t.amount) : Math.abs(t.amount),
-            date: t.date instanceof Date ? t.date : new Date(t.date),
-            categoryId: suggested?.id || null,
-            type: t.type || "EXPENSE",
-            selected: true,
-            isInstallment: installment.isInstallment,
-            currentInstallment: installment.currentInstallment || null,
-            totalInstallments: installment.totalInstallments || null,
-          })
-        }
-      } catch (error) {
-        console.error(`Error processing photo ${i + 1}:`, error)
-      }
-
-      // Update progress
-      if (progressMessageId && i < queueItems.length - 1) {
+      if (ok.length === 0) {
+        // Todas falharam no download — o bloco abaixo trata como "nada encontrado".
+      } else {
         try {
-          await editMessageText(
-            chatId,
-            progressMessageId,
-            `📸 Processando imagem ${i + 2} de ${totalPhotos}... (${allTransactions.length} transações)`
+          const parsed = await parseFilesForImport(
+            ok.map(({ buffer, item }) => ({
+              buffer,
+              mimeType: "image/jpeg",
+              filename: `telegram-${item.fileId}.jpg`,
+              userId,
+            }))
           )
-        } catch {
-          // Ignore edit errors (e.g., message not modified)
+
+          if (parsed.kind === "success") {
+            if (parsed.bank) lastBank = parsed.bank
+            if (parsed.source === "ai") batchUsedAi = true
+            if (parsed.fallbackReason && !batchFallbackReason) {
+              batchFallbackReason = parsed.fallbackReason
+            }
+
+            for (const t of parsed.transactions) {
+              const suggested = await suggestCategory(t.description, userId)
+              const installment = detectInstallment(t.description)
+
+              allTransactions.push({
+                description: t.description,
+                amount: t.type === "EXPENSE" ? -Math.abs(t.amount) : Math.abs(t.amount),
+                date: t.date instanceof Date ? t.date : new Date(t.date),
+                categoryId: suggested?.id || null,
+                type: t.type || "EXPENSE",
+                selected: true,
+                isInstallment: installment.isInstallment,
+                currentInstallment: installment.currentInstallment || null,
+                totalInstallments: installment.totalInstallments || null,
+              })
+            }
+          } else {
+            console.warn(`Telegram unified batch parse failed: ${parsed.error}`)
+          }
+        } catch (err) {
+          console.error("Error processing unified batch:", err)
+        }
+      }
+    } else {
+      // Caminho legado (single image OU AI desabilitada): loop sequencial,
+      // cada foto é 1 chamada ao pipeline. Quando AI está desabilitada,
+      // nenhum uso de quota — então não há bom motivo pra unificar.
+      for (let i = 0; i < queueItems.length; i++) {
+        const item = queueItems[i]
+
+        try {
+          // Download photo
+          const filePath = await getFile(item.fileId)
+          if (!filePath) continue
+          const buffer = await downloadFileBuffer(filePath)
+
+          // Parse via pipeline unificado (notif → AI → regex)
+          const parsed = await parseFileForImport({
+            buffer,
+            mimeType: "image/jpeg", // Telegram photos come as JPEG
+            filename: `telegram-${item.fileId}.jpg`,
+            userId,
+          })
+
+          if (parsed.kind === "error") {
+            // Tracking: se uma foto falhar, pula mas continua o batch.
+            console.warn(`Telegram photo parse failed: ${parsed.error}`)
+            continue
+          }
+
+          if (parsed.bank) lastBank = parsed.bank
+          if (parsed.source === "ai") batchUsedAi = true
+          // Captura o primeiro fallbackReason do batch (prioridade temporal).
+          if (parsed.fallbackReason && !batchFallbackReason) {
+            batchFallbackReason = parsed.fallbackReason
+          }
+
+          // Categorize
+          for (const t of parsed.transactions) {
+            const suggested = await suggestCategory(t.description, userId)
+            const installment = detectInstallment(t.description)
+
+            allTransactions.push({
+              description: t.description,
+              amount: t.type === "EXPENSE" ? -Math.abs(t.amount) : Math.abs(t.amount),
+              date: t.date instanceof Date ? t.date : new Date(t.date),
+              categoryId: suggested?.id || null,
+              type: t.type || "EXPENSE",
+              selected: true,
+              isInstallment: installment.isInstallment,
+              currentInstallment: installment.currentInstallment || null,
+              totalInstallments: installment.totalInstallments || null,
+            })
+          }
+        } catch (error) {
+          console.error(`Error processing photo ${i + 1}:`, error)
+        }
+
+        // Update progress
+        if (progressMessageId && i < queueItems.length - 1) {
+          try {
+            await editMessageText(
+              chatId,
+              progressMessageId,
+              `📸 Processando imagem ${i + 2} de ${totalPhotos}... (${allTransactions.length} transações)`
+            )
+          } catch {
+            // Ignore edit errors (e.g., message not modified)
+          }
         }
       }
     }

--- a/src/lib/telegram/commands.ts
+++ b/src/lib/telegram/commands.ts
@@ -725,12 +725,17 @@ export async function handlePhotoMessage(
   const mediaGroupId = message.media_group_id || `single_${message.message_id}`
 
   // Phase 1: Store file_id in queue
+  // `messageId` persiste a ordem original enviada pelo usuário — o Telegram
+  // garante message_id monotônico dentro de um chat, então ordenar por ele
+  // reconstrói a sequência correta das páginas do álbum (crítico pro caminho
+  // multi-part da IA, que trata as imagens como documento contínuo).
   await prisma.telegramPhotoQueue.create({
     data: {
       chatId: String(chatId),
       userId,
       mediaGroupId,
       fileId: largestPhoto.file_id,
+      messageId: message.message_id,
     },
   })
 
@@ -752,9 +757,18 @@ export async function handlePhotoMessage(
 
   // Phase 3: Process all photos in the batch
   try {
+    // Ordem: messageId primeiro (fonte autoritativa do Telegram, int monotônico
+    // por chat), createdAt como backup (entries muito antigas sem messageId),
+    // id como tiebreak final determinístico. Sem isso, batches multi-part
+    // podem receber páginas fora de ordem e o Gemini interpreta um "documento
+    // contínuo" embaralhado.
     const queueItems = await prisma.telegramPhotoQueue.findMany({
       where: { mediaGroupId, userId },
-      orderBy: { createdAt: "asc" },
+      orderBy: [
+        { messageId: "asc" },
+        { createdAt: "asc" },
+        { id: "asc" },
+      ],
     })
 
     const totalPhotos = queueItems.length


### PR DESCRIPTION
## Summary
- Quando o usuário envia N imagens de fatura/extrato via Telegram (media group), o batch agora vira **1 chamada ao Gemini** via multi-part API em vez de N chamadas separadas.
- Consequência prática: o usuário que mandar 5 fotos de fatura consome **1 cota mensal de IA**, não 5.
- Zero re-encoding de imagem, zero composition em PDF — a API do Gemini já aceita múltiplas `parts` com `inlineData` no mesmo prompt.
- Fallback preservado: se a IA falhar, o batch cai pro loop tradicional imagem-por-imagem (OCR+regex).

## Abordagem escolhida (C): Gemini Multi-Part (API-native)
Feita uma feature farm com 3 abordagens concorrentes em worktrees paralelos, julgadas por sub-agent. Vencedor: **Approach C** — API-native, qualidade 100% preservada.

### Verdict table (judge sub-agent, evidência numérica)

| Critério | A (PDF pdf-lib) | B (image stack sharp) | C (multi-part API) — vencedor |
|---|---|---|---|
| **LOC (diff vs base)** | +375/-51 em 4 arquivos | +337/-51 em 2 arquivos | +936/-71 em 8 arquivos |
| **Novas deps** | +1 (`pdf-lib` ~800KB) | 0 | 0 |
| **Testes** | 695 passando (+8) | 696 passando (+9) | **706 passando (+19)** |
| **Cobertura `lib/ai-parser`** | ~85% | ~87% | **98%** (gemini-client passou de 29% → 95%) |
| **Qualidade do input** | Preserva imagens íntegras como páginas PDF | JPEG lossy (quality 90) + possível downscale | **Zero re-encoding** |
| **Latência extra** | ~50–200ms (compor PDF) | ~100–300ms (sharp composite) | **~0ms** (só base64 encode) |
| **Mix de PDF+imagem** | Possível via `copyPages()` | Precisa rasterizar PDF | **Funciona gratuitamente hoje** |
| **Reuso fora do Telegram** | Precisa abstrair bundle utility | Precisa abstrair bundle utility | **`parseFilesForImport` já é genérico** |

**Critério decisivo**: fidelidade do input + extensibilidade. C não toca nos pixels — apenas usa o que a API do Gemini já oferece. `parseFilesForImport` é reutilizável no endpoint web `/api/import` sem refactor, e mix de PDF+imagem funciona sem código extra.

**Trade-off aceito**: maior volume de LOC (936 vs 337 da B) — mas isso vem de manter retrocompat via overloads em 5 camadas + cobertura de testes 2× maior (19 testes novos).

**Quando reconsiderar**: se atingirmos regularmente o teto de ~20MB base64 somado (limite do Gemini inline), migrar pra Files API. Nesse cenário, Approach A (PDF bundlado) fica mais competitivo.

## Mudanças (arquivos)

**Produção (~215 LOC):**
- `src/lib/ai-parser/gemini-client.ts` — overload aceita `Array<{buffer, mimeType}>`, mapeia N parts no `contents`
- `src/lib/ai-parser/invoice-parser.ts` — `parseFileWithAi` aceita array (retrocompat via overload)
- `src/lib/ai-parser/prompt.ts` — nova regra "DOCUMENTO MULTI-IMAGEM" no SYSTEM_PROMPT
- `src/lib/parse-pipeline.ts` — nova função `parseFilesForImport(inputs[])` que reserva 1 cota e agrega resultado; fallback roda OCR individual por arquivo
- `src/lib/telegram/commands.ts` — Phase 3 bifurca: `queueItems.length >= 2 && GEMINI_API_KEY` → `parseFilesForImport` 1x; caso contrário, loop legacy

**Testes (+19):**
- `src/lib/ai-parser/gemini-client.test.ts` (novo, 5 tests)
- `src/lib/ai-parser/invoice-parser.test.ts` (+2)
- `src/lib/parse-pipeline.test.ts` (+9)
- `src/lib/telegram/commands.test.ts` (+3)

## Ranking final dos approaches

1. **C (vencedor)** — API-native, zero perda de qualidade, cobertura 2× maior, abstração reutilizável.
2. **B** — menor footprint (337 LOC, 2 arquivos, 0 deps), mas JPEG lossy + downscale em stacks grandes.
3. **A** — solução elegante mas puxa `pdf-lib` pra um problema que a API resolve nativamente.

Os `APPROACH.md` de A e B ficam salvos em `/tmp/approach-{a,b}.md` localmente (worktrees foram removidos). Se quiser acessar, me avise que recupero.

## Test plan
- [ ] `npm run test:unit -- --run` — 706 testes verdes
- [ ] Manualmente: enviar 3 fotos de uma fatura (Nubank/C6) via Telegram como media group, verificar que só 1 cota é consumida (`GET /api/ai/usage`)
- [ ] Manualmente: enviar 1 foto só, verificar que caminho legacy é mantido
- [ ] Manualmente: com `GEMINI_API_KEY` vazia, enviar 3 fotos, verificar que loop sequencial fallback é usado
- [ ] Verificar mensagem de progresso: "📸 Unificando 3 imagens em documento único..." no caminho novo
